### PR TITLE
Add modern resize functionality on controls.

### DIFF
--- a/src/components/Figure/Figure.styled.ts
+++ b/src/components/Figure/Figure.styled.ts
@@ -1,5 +1,11 @@
 import { styled } from "stitches";
 
+const Width = styled("div", {
+  position: "absolute",
+  width: "100%",
+  backgroundColor: "green",
+});
+
 const FigureStyled = styled("figure", {
   display: "flex",
   flexDirection: "column",
@@ -7,7 +13,6 @@ const FigureStyled = styled("figure", {
   flexGrow: "0",
   flexShrink: "0",
   borderRadius: "3px",
-  transition: "$all",
 
   figcaption: {
     display: "flex",
@@ -25,6 +30,10 @@ const FigureStyled = styled("figure", {
         figcaption: {
           padding: "$2",
           color: "$accent",
+        },
+
+        [`& ${Width}`]: {
+          width: "calc(100% - ($2 * 2))",
         },
       },
     },
@@ -69,4 +78,4 @@ const Description = styled("span", {
   color: "$primary",
 });
 
-export { FigureStyled, Image, Placeholder, Title, Description };
+export { FigureStyled, Image, Placeholder, Title, Description, Width };

--- a/src/components/Figure/Figure.tsx
+++ b/src/components/Figure/Figure.tsx
@@ -6,15 +6,18 @@ import {
   Image,
   Placeholder,
   Title,
+  Width,
 } from "./Figure.styled";
 import * as AspectRatio from "@radix-ui/react-aspect-ratio";
 import { ContentResource } from "@iiif/presentation-3";
 import Video from "./Video";
+import { useCollectionDispatch } from "context/collection-context";
 
 interface FigureProps {
   caption: string;
   description: string;
   image: string | null;
+  index: number;
   video: ContentResource | null;
   isFocused: boolean;
 }
@@ -23,11 +26,14 @@ const Figure: React.FC<FigureProps> = ({
   caption,
   description,
   image,
+  index,
   isFocused,
   video,
 }) => {
+  const dispatch: any = useCollectionDispatch();
   const [loaded, setLoaded] = useState(false);
   const imgRef = useRef<HTMLImageElement>(null);
+  const widthRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     if (imgRef.current && imgRef.current.complete) setLoaded(true);
@@ -37,9 +43,33 @@ const Figure: React.FC<FigureProps> = ({
     setLoaded(false);
   }, [image]);
 
+  useEffect(() => {
+    const resizeObserver = new ResizeObserver(
+      (entries: ResizeObserverEntry[]) => {
+        for (let entry of entries) {
+          if (entry.contentBoxSize) {
+            const contentBoxSize: ResizeObserverSize = Array.isArray(
+              entry.contentBoxSize
+            )
+              ? entry.contentBoxSize[0]
+              : entry.contentBoxSize;
+            dispatch({
+              type: "updateItemHeight",
+              itemHeight: contentBoxSize.inlineSize,
+            });
+          }
+        }
+      }
+    );
+
+    if (index === 0 && widthRef.current)
+      resizeObserver.observe(widthRef.current);
+  }, [index, loaded]);
+
   return (
     <FigureStyled isFocused={isFocused}>
       <AspectRatio.Root ratio={1 / 1}>
+        <Width ref={widthRef} />
         <Placeholder>
           {video && <Video resource={video} isFocused={isFocused} />}
           {image && (

--- a/src/components/Items/Control.styled.ts
+++ b/src/components/Items/Control.styled.ts
@@ -44,6 +44,7 @@ const ControlStyled = styled("button", {
 
   [`&:disabled`]: {
     opacity: "0",
+    transform: "scale(0)",
   },
 
   [`&:hover`]: {

--- a/src/components/Items/Item.tsx
+++ b/src/components/Items/Item.tsx
@@ -14,10 +14,11 @@ import { Anchor, ItemStyled } from "./Item.styled";
 import Preview from "components/Preview/Preview";
 
 interface ItemProps {
+  index: number;
   item: Collection | Manifest;
 }
 
-const Item: React.FC<ItemProps> = ({ item }) => {
+const Item: React.FC<ItemProps> = ({ index, item }) => {
   const store = useCollectionState();
   const { vault } = store;
 
@@ -118,6 +119,7 @@ const Item: React.FC<ItemProps> = ({ item }) => {
             ) as unknown as string
           }
           image={image as string | null}
+          index={index}
           video={video as ContentResource | null}
           isFocused={isFocused}
         />

--- a/src/components/Items/Items.tsx
+++ b/src/components/Items/Items.tsx
@@ -4,30 +4,19 @@ import { CollectionItems, Collection, Manifest } from "@iiif/presentation-3";
 import { ItemsStyled } from "./Items.styled";
 import ItemsControl from "./Control";
 import { rem } from "stitches";
-
-const useRefDimensions = (ref: React.RefObject<HTMLElement>) => {
-  const [dimensions, setDimensions] = useState({ width: 0, height: 0 });
-  React.useEffect(() => {
-    if (ref.current) {
-      const { current } = ref;
-      const boundingRect = current.getBoundingClientRect();
-      const { width, height } = boundingRect;
-      setDimensions({ width: Math.round(width), height: Math.round(height) });
-    }
-  }, []);
-  return dimensions;
-};
+import { useCollectionState } from "context/collection-context";
 
 interface ItemsProps {
   items: CollectionItems[];
 }
 
 const Items: React.FC<ItemsProps> = ({ items }) => {
+  const store = useCollectionState();
+  const { itemHeight } = store;
   const [activeItems, setActiveItems] = useState<number[]>([0, 1, 2, 3, 4]);
   const [hasPrev, setHasPrev] = useState<boolean>(false);
   const [hasNext, setHasNext] = useState<boolean>(false);
   const itemsRef = useRef<HTMLElement>(null);
-  const dimensions = useRefDimensions(itemsRef);
 
   useEffect(() => {
     if (!items) return;
@@ -42,35 +31,36 @@ const Items: React.FC<ItemsProps> = ({ items }) => {
     setActiveItems(activeItems.map((index) => index + increment));
   };
 
-  /**
-   * move this elsewhere as hook or service....
-   */
-  let gaps = rem * 1.618 * 4;
-  let instance = dimensions.width - gaps;
-  let controlHeight = instance / 5;
-
   return (
     <ItemsStyled ref={itemsRef}>
-      <ItemsControl
-        increment={-1}
-        label="previous"
-        handleControl={handleActiveItems}
-        height={controlHeight}
-        disabled={!hasPrev}
-      />
-      <ItemsControl
-        increment={1}
-        label="next"
-        handleControl={handleActiveItems}
-        height={controlHeight}
-        disabled={!hasNext}
-      />
+      {itemHeight && (
+        <>
+          <ItemsControl
+            increment={-1}
+            label="previous"
+            handleControl={handleActiveItems}
+            height={itemHeight}
+            disabled={!hasPrev}
+          />
+          <ItemsControl
+            increment={1}
+            label="next"
+            handleControl={handleActiveItems}
+            height={itemHeight}
+            disabled={!hasNext}
+          />
+        </>
+      )}
       {items
         .filter((item, index) => {
           if (activeItems.includes(index)) return item;
         })
-        .map((item) => (
-          <Item item={item as Collection | Manifest} key={item.id} />
+        .map((item, index) => (
+          <Item
+            index={index}
+            item={item as Collection | Manifest}
+            key={item.id}
+          />
         ))}
     </ItemsStyled>
   );

--- a/src/context/collection-context.tsx
+++ b/src/context/collection-context.tsx
@@ -3,16 +3,19 @@ import { Vault } from "@iiif/vault";
 
 interface CollectionContextStore {
   isLoaded: boolean;
+  itemHeight: number | undefined;
   vault: Vault;
 }
 
 interface CollectionAction {
   type: string;
+  itemHeight: number | undefined;
   isLoaded: boolean;
 }
 
 const defaultState: CollectionContextStore = {
   isLoaded: false,
+  itemHeight: undefined,
   vault: new Vault(),
 };
 
@@ -30,6 +33,12 @@ function collectionReducer(
       return {
         ...state,
         isLoaded: action.isLoaded,
+      };
+    }
+    case "updateItemHeight": {
+      return {
+        ...state,
+        itemHeight: action.itemHeight,
       };
     }
     default: {


### PR DESCRIPTION
## What does this do?

This adds resize functionality on the controls (are shown in red below) that are rendered with the `Items` component. Previously the controls did not resize automatically with the flex based items as they are absolutely positioned. 

This PR adds a [resizeObserver](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver) that watches the first item for any resizing and then dispatches the size of this to the global context. This context is then communicated to the control as a prop.

![image](https://user-images.githubusercontent.com/7376450/161661459-b4a027ba-838e-4934-a3f1-761d51eaf2b2.png)

Expected behavior is that the items controls (next and previous arrows) now resize the the height of the square aspect ratio figures in each item.
