### PR TITLE
Add dynamic url functionality to dev examples.

### DIFF
--- a/src/components/Header/Header.styled.ts
+++ b/src/components/Header/Header.styled.ts
@@ -10,7 +10,8 @@ const HeaderStyled = styled("div", {
 
 const Title = styled("span", {
   fontSize: "$5",
-  fontWeight: "800",
+  fontWeight: "400",
+  fontFamily: "$display",
 
   a: {
     color: "$accent",

--- a/src/dev.tsx
+++ b/src/dev.tsx
@@ -1,18 +1,19 @@
 import React from "react";
 import ReactDOM from "react-dom";
 import App from "./index";
+import DynamicUrl from "./dev/DynamicUrl";
+import { collections } from "./dev/collections";
 
-let collectionNezPerce: string = `http://127.0.0.1:8080//fixtures/iiif/collection/nez-perce.json`;
-let collectionMasks: string = `https://raw.githubusercontent.com/samvera-labs/bloom-iiif/main/public/fixtures/iiif/collection/masks-of-antonio-fava.json`;
-let collectionFootball: string = `https://raw.githubusercontent.com/samvera-labs/bloom-iiif/main/public/fixtures/iiif/collection/athletic-department-footbal-films.json`;
-let collectionBodleianGraeca: string = `https://iiif.bodleian.ox.ac.uk/iiif/collection/flora-and-fauna-graeca`;
-let collectionBodleianMaps: string = `https://iiif.bodleian.ox.ac.uk/iiif/collection/maps`;
-let collectionScotland: string = `https://view.nls.uk/collections/7446/74462370.json`;
-let collectionHeilman: string = `https://digital.lib.utk.edu/assemble/collection/collections/heilman`;
+const Wrapper = () => {
+  const defaultUrl: string = collections[0].url;
 
-ReactDOM.render(
-  <section>
-    <App collectionId={collectionMasks} />
-  </section>,
-  document.getElementById("root")
-);
+  const [url, setUrl] = React.useState(defaultUrl);
+  return (
+    <>
+      <App collectionId={url} key={url} />
+      <DynamicUrl url={url} setUrl={setUrl} />
+    </>
+  );
+};
+
+ReactDOM.render(<Wrapper />, document.getElementById("root"));

--- a/src/dev/DynamicUrl.styled.tsx
+++ b/src/dev/DynamicUrl.styled.tsx
@@ -1,0 +1,92 @@
+import { styled } from "@stitches/react";
+
+const DynamicUrlStyled = styled("section", {
+  display: "flex",
+  flexDirection: "column",
+  alignItems: "center",
+  padding: "2rem",
+});
+
+const ManualForm = styled("form", {
+  display: "flex",
+  justifyContent: "center",
+  flexDirection: "column",
+  alignItems: "center",
+  width: "61.8%",
+
+  label: {
+    display: "block",
+    marginBottom: "1rem",
+    fontSize: "1.25rem",
+    color: "$primary",
+    fontWeight: "400",
+    fontFamily: "$display",
+  },
+
+  "> div": {
+    display: "flex",
+    backgroundColor: "$secondaryMuted",
+    position: "relative",
+    width: "100%",
+    borderRadius: "3px",
+
+    input: {
+      padding: "0.618rem 1rem",
+      background: "transparent",
+      color: "$primary",
+      border: "none",
+      fontFamily: "$sans",
+      width: "100%",
+    },
+
+    button: {
+      padding: "0.382rem 0.618rem",
+      cursor: "pointer",
+      position: "absolute",
+      right: "0.382rem",
+      alignSelf: "center",
+      background: "$secondary",
+      border: "none",
+      fontSize: "0.7222rem",
+      fontFamily: "$sans",
+      fontWeight: "700",
+      borderRadius: "3px",
+      backgroundColor: "$secondary",
+      color: "$primary",
+    },
+  },
+});
+
+const Curated = styled("div", {
+  padding: "2rem",
+  display: "flex",
+  justifyContent: "center",
+  flexWrap: "wrap",
+});
+
+const ButtonForm = styled("form", {
+  button: {
+    backgroundColor: "$transparent",
+    border: "none",
+    outline: "1px solid $secondaryMuted",
+    color: "$primaryMuted",
+    fontFamily: "$sans",
+    fontSize: "0.8333rem",
+    height: "2rem",
+    padding: "0 1rem",
+    borderRadius: "1rem",
+    cursor: "pointer",
+    margin: "0.5rem",
+  },
+
+  "&[data-active='true']": {
+    button: {
+      color: "$secondary",
+      fontWeight: "700",
+      backgroundColor: "$accent",
+      outline: "1px solid $accent",
+    },
+  },
+});
+
+export { DynamicUrlStyled, Curated, ManualForm, ButtonForm };

--- a/src/dev/DynamicUrl.tsx
+++ b/src/dev/DynamicUrl.tsx
@@ -1,0 +1,69 @@
+import React, {
+  Dispatch,
+  FormEvent,
+  SetStateAction,
+  useEffect,
+  useRef,
+} from "react";
+import {
+  ButtonForm,
+  Curated,
+  DynamicUrlStyled,
+  ManualForm,
+} from "./DynamicUrl.styled";
+import { collections } from "./collections";
+
+interface DynamicUrlProps {
+  url: string;
+  setUrl: Dispatch<SetStateAction<string>>;
+}
+
+const DynamicUrl: React.FC<DynamicUrlProps> = ({ url, setUrl }) => {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    const target = e.target as typeof e.target & {
+      url: { value: string };
+    };
+    setUrl(target.url?.value);
+  };
+
+  useEffect(() => {
+    if (inputRef.current) inputRef.current.value = url;
+  }, [url]);
+
+  return (
+    <DynamicUrlStyled>
+      <ManualForm onSubmit={handleSubmit}>
+        <label htmlFor="manual-collection">View a IIIF Collection</label>
+        <div>
+          <input
+            type="text"
+            name="url"
+            id="manual-collection"
+            placeholder="IIIF Collection"
+            ref={inputRef}
+          />
+          <button type="submit">View</button>
+        </div>
+      </ManualForm>
+      {collections.length > 0 && (
+        <Curated>
+          {collections.map((obj) => (
+            <ButtonForm
+              key={obj.label}
+              onSubmit={handleSubmit}
+              data-active={url === obj.url ? true : false}
+            >
+              <button name="url" value={obj.url}>
+                {obj.label}
+              </button>
+            </ButtonForm>
+          ))}
+        </Curated>
+      )}
+    </DynamicUrlStyled>
+  );
+};
+
+export default DynamicUrl;

--- a/src/dev/collections.ts
+++ b/src/dev/collections.ts
@@ -1,0 +1,14 @@
+export const collections = [
+  {
+    url: "https://raw.githubusercontent.com/samvera-labs/bloom-iiif/main/public/fixtures/iiif/collection/masks-of-antonio-fava.json",
+    label: "Masks of Antonio Fava",
+  },
+  {
+    url: "https://iiif.bodleian.ox.ac.uk/iiif/collection/flora-and-fauna-graeca",
+    label: "Flora and Fauna Graeca",
+  },
+  {
+    url: "https://raw.githubusercontent.com/samvera-labs/bloom-iiif/main/public/fixtures/iiif/collection/athletic-department-footbal-films.json",
+    label: "Football Films",
+  },
+];

--- a/src/stitches.tsx
+++ b/src/stitches.tsx
@@ -52,7 +52,7 @@ export const theme = {
   },
   fonts: {
     sans: "'Inter', Arial, sans-serif",
-    display: "'Inter', Arial, sans-serif",
+    display: "'Calistoga', 'Inter', Arial, sans-serif",
   },
   fontSizes: {
     1: "0.611rem",


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/7376450/162040486-4e121d9e-b448-4488-b949-26af257cf302.png)

### What's this do?
This adds an input form to update collection IDs in the example Bloom app, including a curated set of collections that showcase Bloom.

### How do I review locally?
1. Pull down the branch
2. run `npm run build:static`
3. run `npx serve static`