### PR TITLE
Upgrade Nectar, address key prop issue.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@iiif/vault": "^0.9.18",
         "@radix-ui/react-aspect-ratio": "^0.1.4",
-        "@samvera/nectar-iiif": "^0.0.9",
+        "@samvera/nectar-iiif": "^0.0.10",
         "@stitches/react": "^1.2.7",
         "react": "^16.13.1  || ^17.0 || ^18.0",
         "react-dom": "^16.13.1  || ^17.0 || ^18.0"
@@ -1080,9 +1080,9 @@
       }
     },
     "node_modules/@samvera/nectar-iiif": {
-      "version": "0.0.9",
-      "resolved": "https://registry.npmjs.org/@samvera/nectar-iiif/-/nectar-iiif-0.0.9.tgz",
-      "integrity": "sha512-WKmhvIKYInW9SwXluCHvq6zXuXXGE/TIEjPmS8troRAiYQaDz6iBSA1wiHWwKmKgmpIr19DtJKlcLk7RG5McRQ==",
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/@samvera/nectar-iiif/-/nectar-iiif-0.0.10.tgz",
+      "integrity": "sha512-VrJ4ZTJ/WT8TNTjVL2Nkp1L79taNruPzPSFhlHc9Dfvvml6JKjwQWPKtm0Hg9DsnhlWmYO1fcVyLDoUrTntZOQ==",
       "dependencies": {
         "@stitches/react": "^1.2.7",
         "hls.js": "^1.1.5",
@@ -8944,9 +8944,9 @@
       }
     },
     "@samvera/nectar-iiif": {
-      "version": "0.0.9",
-      "resolved": "https://registry.npmjs.org/@samvera/nectar-iiif/-/nectar-iiif-0.0.9.tgz",
-      "integrity": "sha512-WKmhvIKYInW9SwXluCHvq6zXuXXGE/TIEjPmS8troRAiYQaDz6iBSA1wiHWwKmKgmpIr19DtJKlcLk7RG5McRQ==",
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/@samvera/nectar-iiif/-/nectar-iiif-0.0.10.tgz",
+      "integrity": "sha512-VrJ4ZTJ/WT8TNTjVL2Nkp1L79taNruPzPSFhlHc9Dfvvml6JKjwQWPKtm0Hg9DsnhlWmYO1fcVyLDoUrTntZOQ==",
       "requires": {
         "@stitches/react": "^1.2.7",
         "hls.js": "^1.1.5",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   "dependencies": {
     "@iiif/vault": "^0.9.18",
     "@radix-ui/react-aspect-ratio": "^0.1.4",
-    "@samvera/nectar-iiif": "^0.0.9",
+    "@samvera/nectar-iiif": "^0.0.10",
     "@stitches/react": "^1.2.7",
     "react": "^16.13.1  || ^17.0 || ^18.0",
     "react-dom": "^16.13.1  || ^17.0 || ^18.0"


### PR DESCRIPTION
## What does this do?
This is updates Nectar from 0.0.9 to 0.0.10 and address the React related `key` prop issue.

## To Review

### 1
- See https://samvera-labs.github.io/bloom-iiif/ and inspect, the `key` prop error will be visible.

### 2

- `npm ci` (should update `node_modules` without change `package-lock.json`)
- `npm run dev`
- Inspect local instance, `key` prop error is gone
