### PR TITLE
Include summary on items if exists.

### DIFF
--- a/src/components/Figure/Figure.styled.ts
+++ b/src/components/Figure/Figure.styled.ts
@@ -1,3 +1,4 @@
+import { Label, Summary, Thumbnail } from "@samvera/nectar-iiif";
 import { styled } from "stitches";
 
 const Width = styled("div", {
@@ -13,6 +14,7 @@ const FigureStyled = styled("figure", {
   flexGrow: "0",
   flexShrink: "0",
   borderRadius: "3px",
+  transition: "$all",
 
   img: {
     position: "absolute",
@@ -44,7 +46,7 @@ const FigureStyled = styled("figure", {
     flexDirection: "column",
     padding: "$2 0",
     color: "$primary",
-    transition: "$load",
+    transition: "$all",
   },
 
   variants: {
@@ -79,15 +81,15 @@ const Placeholder = styled("span", {
   transition: "$all",
 });
 
-const Title = styled("span", {
+const Title = styled(Label, {
   fontSize: "$3",
   fontWeight: "700",
 });
 
-const Description = styled("span", {
-  fontSize: "$1",
+const Description = styled(Summary, {
+  fontSize: "$2",
   marginTop: "$1",
   color: "$primary",
 });
 
-export { FigureStyled, Image, Placeholder, Title, Description, Width };
+export { FigureStyled, Placeholder, Title, Description, Width };

--- a/src/components/Figure/Figure.tsx
+++ b/src/components/Figure/Figure.tsx
@@ -1,21 +1,30 @@
 import React, { useEffect, useRef, useState } from "react";
-import { FigureStyled, Placeholder, Width } from "./Figure.styled";
+import {
+  Description,
+  FigureStyled,
+  Placeholder,
+  Title,
+  Width,
+} from "./Figure.styled";
 import * as AspectRatio from "@radix-ui/react-aspect-ratio";
 import { useCollectionDispatch } from "context/collection-context";
-import { Label, Thumbnail } from "@samvera/nectar-iiif";
+import { Label, Summary, Thumbnail } from "@samvera/nectar-iiif";
+import { InternationalString } from "@iiif/presentation-3";
 
 interface FigureProps {
-  label: any;
+  label: InternationalString;
+  summary?: InternationalString;
   thumbnail: any;
   index: number;
   isFocused: boolean;
 }
 
 const Figure: React.FC<FigureProps> = ({
-  label,
-  thumbnail,
   index,
   isFocused,
+  label,
+  summary,
+  thumbnail,
 }) => {
   const dispatch: any = useCollectionDispatch();
   const [loaded, setLoaded] = useState(false);
@@ -60,7 +69,8 @@ const Figure: React.FC<FigureProps> = ({
         </Placeholder>
       </AspectRatio.Root>
       <figcaption>
-        <Label label={label} css={{ fontWeight: "700", fontSize: "$2" }} />
+        <Title label={label} />
+        {summary && <Description summary={summary} />}
       </figcaption>
     </FigureStyled>
   );

--- a/src/components/Items/Item.tsx
+++ b/src/components/Items/Item.tsx
@@ -84,11 +84,12 @@ const Item: React.FC<ItemProps> = ({ index, item }) => {
         onMouseLeave={onBlur}
       >
         <Figure
-          key={id}
-          label={item.label}
-          thumbnail={thumbnail}
           index={index}
           isFocused={isFocused}
+          key={id}
+          label={item.label}
+          summary={item.summary}
+          thumbnail={thumbnail}
         />
         <Preview
           manifest={manifest as Manifest}

--- a/src/components/Preview/Preview.styled.ts
+++ b/src/components/Preview/Preview.styled.ts
@@ -69,6 +69,4 @@ const Label = styled("div", {
   cursor: "default",
 });
 
-// linear-gradient(90deg, rgba(0,0,0,0.7) 38.2%, rgba(0,0,0,0) 98%)"
-
 export { Controls, Label, Overlay, PreviewStyled };


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/7376450/170156781-8962c283-57ea-4cbe-ac8c-945c0e8c4ecf.png)

## What does this do?

This change adds back rendering of a `item.summary` after the Nectar refactor, shown above as **Video** for each item. This was removed and accidentally omitted during the changeover. I also adjusted the CSS transitions for a smoother hover experience, and text no longer blips and wraps when the hover transitions occur.