### PR TITLE
Update slider item sizing

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **UI componentry for IIIF Collections**
 
-#### [Demo](https://samvera-labs.github.io/bloom-iiif)  |  [Code](https://github.com/samvera-labs/bloom-iiif)
+#### [Demo](https://samvera-labs.github.io/bloom-iiif) | [Code](https://github.com/samvera-labs/bloom-iiif)
 
 _Note, Bloom is still in early development._
 
@@ -57,10 +57,36 @@ const collectionId = `https://raw.githubusercontent.com/samvera-labs/bloom-iiif/
 return <BloomIIIF collectionId={collectionId} />;
 ```
 
+<h3>Responsive breakpoints</h3>
+Bloom uses default values per <a href="https://swiperjs.com/swiper-api#param-breakpoints" target="_blank">Swiper's `breakpoints` API </a>.  You may customize your own by passing in a `breakpoints` object, ie:
+
+```jsx
+const myBreakpoints = {
+  320: {
+    slidesPerView: 2,
+    spaceBetween: 20
+  },
+  480: {
+    slidesPerView: 3,
+    spaceBetween: 30
+  },
+  640: {
+    slidesPerView: 4,
+    spaceBetween: 40
+  }
+};
+
+<BloomIIIF
+  collectionId={...}
+  options={{
+    breakpoints: myBreakpoints
+  }}
+/>
+```
+
 <h3>Next.js</h3>
 
 Usage with Next.js requires a dynamic import using `next/dynamic`
-
 
 ```jsx
 import dynamic from "next/dynamic";
@@ -69,9 +95,7 @@ const BloomIIIF = dynamic(() => import("@samvera/bloom-iiif"), {
   ssr: false,
 });
 
-
-return <BloomIIIF collectionId={collectionId} />
-
+return <BloomIIIF collectionId={collectionId} />;
 ```
 
 ---

--- a/src/components/Items/Items.styled.ts
+++ b/src/components/Items/Items.styled.ts
@@ -1,9 +1,7 @@
 import { styled } from "stitches";
 
 const ItemsStyled = styled("div", {
-  position: "relative",
-  display: "flex",
-  flexDirection: "row",
+  "& .swiper-slide": {},
 });
 
 export { ItemsStyled };

--- a/src/components/Items/Items.tsx
+++ b/src/components/Items/Items.tsx
@@ -1,34 +1,51 @@
 import React, { useEffect, useRef, useState } from "react";
 import { CollectionItems, Collection, Manifest } from "@iiif/presentation-3";
+import { SwiperBreakpoints } from "../../../types/types";
 import Item from "./Item";
 import { ItemsStyled } from "./Items.styled";
 import { Navigation, A11y } from "swiper";
 import { Swiper, SwiperSlide } from "swiper/react";
 
 interface ItemsProps {
+  breakpoints?: SwiperBreakpoints;
   instance: string;
   items: CollectionItems[];
 }
 
-const Items: React.FC<ItemsProps> = ({ instance, items }) => {
-  const [itemCount, setItemCount] = useState(3);
+const defaultBreakpoints = {
+  640: {
+    slidesPerView: 2,
+    slidesPerGroup: 2,
+    spaceBetween: 20,
+  },
+  768: {
+    slidesPerView: 3,
+    slidesPerGroup: 3,
+    spaceBetween: 30,
+  },
+  1024: {
+    slidesPerView: 4,
+    slidesPerGroup: 4,
+    spaceBetween: 40,
+  },
+  1366: {
+    slidesPerView: 5,
+    slidesPerGroup: 5,
+    spaceBetween: 50,
+  },
+  1920: {
+    slidesPerView: 6,
+    slidesPerGroup: 6,
+    spaceBetween: 60,
+  },
+};
+
+const Items: React.FC<ItemsProps> = ({
+  breakpoints = defaultBreakpoints,
+  instance,
+  items,
+}) => {
   const itemsRef = useRef<HTMLDivElement>(null);
-  const length = items.length;
-
-  useEffect(() => {
-    const resizeObserver = new ResizeObserver(
-      (entries: ResizeObserverEntry[]) => {
-        for (let entry of entries) {
-          if (entry && itemsRef.current?.clientWidth) {
-            let count = Math.ceil(itemsRef.current?.clientWidth / 290);
-            count <= length ? setItemCount(count) : setItemCount(length);
-          }
-        }
-      }
-    );
-
-    if (itemsRef.current) resizeObserver.observe(itemsRef.current);
-  }, [itemsRef.current]);
 
   return (
     <ItemsStyled ref={itemsRef}>
@@ -43,8 +60,9 @@ const Items: React.FC<ItemsProps> = ({ instance, items }) => {
           nextEl: `.bloom-next-${instance}`,
           prevEl: `.bloom-previous-${instance}`,
         }}
-        slidesPerGroup={itemCount}
-        slidesPerView={itemCount}
+        slidesPerView={2}
+        slidesPerGroup={2}
+        breakpoints={breakpoints}
       >
         {items.map((item, index) => (
           <SwiperSlide key={`${item.id}-${index}`}>

--- a/src/dev.tsx
+++ b/src/dev.tsx
@@ -12,6 +12,12 @@ import { collections } from "./dev/collections";
 const Wrapper = () => {
   const defaultUrl: string = collections[0].url;
 
+  const oneItem =
+    "https://dcapi.rdc-staging.library.northwestern.edu/api/v2/search?query=subject.label:%22Sculpture,%20English--19th%20century%22&collectionLabel=Sculpture,%20English--19th%20century&collectionSummary=Subject&as=iiif";
+
+  const twoItems =
+    "https://dcapi.rdc-staging.library.northwestern.edu/api/v2/search?query=collection.title.keyword:%22Transportation%20Library%20Menu%20Collection%22&collectionLabel=Transportation%20Library%20Menu%20Collection&collectionSummary=Collection&as=iiif";
+
   const [url, setUrl] = React.useState(defaultUrl);
   return (
     <>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,33 +1,36 @@
 import React, { useEffect, useState } from "react";
 import {
-  CollectionProvider,
-  useCollectionState,
-} from "context/collection-context";
-import Items from "components/Items/Items";
-import Header from "components/Header/Header";
-import {
   CollectionItems,
   CollectionNormalized,
   ContentResource,
   InternationalString,
 } from "@iiif/presentation-3";
-import { styled } from "stitches";
+import {
+  CollectionProvider,
+  useCollectionState,
+} from "context/collection-context";
+import { ConfigOptions } from "../types/types";
+import Header from "components/Header/Header";
+import Items from "components/Items/Items";
 import hash from "lib/hash";
+import { styled } from "stitches";
 
-interface Props {
+interface BloomProps {
   collectionId: string;
+  options?: ConfigOptions;
 }
 
-const App: React.FC<Props> = (props) => (
+const App: React.FC<BloomProps> = (props) => (
   <CollectionProvider>
     <Bloom {...props} />
   </CollectionProvider>
 );
 
-const Bloom: React.FC<Props> = ({ collectionId }) => {
+const Bloom: React.FC<BloomProps> = ({ collectionId, options = {} }) => {
   const store = useCollectionState();
   const { vault } = store;
   const [collection, setCollection] = useState<CollectionNormalized>();
+
   /**
    * todo: add wrapping context and store vault
    */
@@ -68,6 +71,9 @@ const Bloom: React.FC<Props> = ({ collectionId }) => {
       <Items
         items={collection.items as CollectionItems[]}
         instance={instance}
+        breakpoints={
+          Boolean(options.breakpoints) ? options.breakpoints : undefined
+        }
       />
     </StyledBloom>
   );

--- a/types/types.ts
+++ b/types/types.ts
@@ -1,0 +1,7 @@
+import { SwiperProps } from "swiper/react";
+
+export interface ConfigOptions {
+  breakpoints?: SwiperBreakpoints;
+}
+
+export type SwiperBreakpoints = SwiperProps["breakpoints"];


### PR DESCRIPTION
## What does this do?
- Update slider item sizing to not extend full width of slider for small number of items.  This uses `Swiper`'s `breakpoints` API instead of custom code to handle viewport resizing.  Not sure if it's the best approach, but seems to handle things ok w/ less code.
- Provide configuration for custom responsive breakpoints

<img width="1322" alt="image" src="https://user-images.githubusercontent.com/3020266/200957558-8d1045da-ce79-4586-9191-6b294c69e376.png">

## How to test
- Add an extra `<App />` component  to `src/dev.tsx`, and provide one of the two test URLS (`oneItem` or `twoItem`)
- Add some custom breakpoints per the updated README