### PR TITLE
20 replace vault

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.3.4",
       "license": "MIT",
       "dependencies": {
+        "@iiif/parser": "^1.1.0",
         "@iiif/vault": "^0.9.19",
         "@radix-ui/react-aspect-ratio": "^1.0.1",
         "@samvera/nectar-iiif": "^0.0.18",
@@ -696,19 +697,19 @@
       }
     },
     "node_modules/@iiif/parser": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/@iiif/parser/-/parser-1.0.10.tgz",
-      "integrity": "sha512-z8b8a02ltoBoKGetfyM4rqIXQ+gnE5rjGXKqzZwvWSAN0hnzA5nghTqisogYo0bQx3ct/Q1bIysvpMMR64uIUQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@iiif/parser/-/parser-1.1.0.tgz",
+      "integrity": "sha512-p2pqngR/L+ML+LS8Ah70CTITgW192fmWXxOovSapQnI5rKN6daYrbjl5UuIK9R+n0lFFlJwjW5+tA96E+V39hw==",
       "dependencies": {
-        "@iiif/presentation-2": "^1.0.1",
-        "@iiif/presentation-3": "^1.0.4",
+        "@iiif/presentation-2": "^1.0.4",
+        "@iiif/presentation-3": "^1.1.3",
         "@types/geojson": "^7946.0.8"
       }
     },
     "node_modules/@iiif/presentation-2": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@iiif/presentation-2/-/presentation-2-1.0.1.tgz",
-      "integrity": "sha512-iWF6rgAi9ksSwbH/4uJW1/49DOL1wN2mLKovu0qy1GYtCTg42bryAxYtnBsw6LrJZWykTStv7R3DynChfECmnA==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@iiif/presentation-2/-/presentation-2-1.0.4.tgz",
+      "integrity": "sha512-hJakpq62VBajesLJrYPtFm6hcn6c/HkKP7CmKZ5atuzu40m0nifWYsqigR1l9sZGvhhHb/DRshPmiW/0GNrJoA==",
       "peerDependencies": {
         "@iiif/presentation-3": "*"
       }
@@ -8709,19 +8710,19 @@
       "optional": true
     },
     "@iiif/parser": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/@iiif/parser/-/parser-1.0.10.tgz",
-      "integrity": "sha512-z8b8a02ltoBoKGetfyM4rqIXQ+gnE5rjGXKqzZwvWSAN0hnzA5nghTqisogYo0bQx3ct/Q1bIysvpMMR64uIUQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@iiif/parser/-/parser-1.1.0.tgz",
+      "integrity": "sha512-p2pqngR/L+ML+LS8Ah70CTITgW192fmWXxOovSapQnI5rKN6daYrbjl5UuIK9R+n0lFFlJwjW5+tA96E+V39hw==",
       "requires": {
-        "@iiif/presentation-2": "^1.0.1",
-        "@iiif/presentation-3": "^1.0.4",
+        "@iiif/presentation-2": "^1.0.4",
+        "@iiif/presentation-3": "^1.1.3",
         "@types/geojson": "^7946.0.8"
       }
     },
     "@iiif/presentation-2": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@iiif/presentation-2/-/presentation-2-1.0.1.tgz",
-      "integrity": "sha512-iWF6rgAi9ksSwbH/4uJW1/49DOL1wN2mLKovu0qy1GYtCTg42bryAxYtnBsw6LrJZWykTStv7R3DynChfECmnA==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@iiif/presentation-2/-/presentation-2-1.0.4.tgz",
+      "integrity": "sha512-hJakpq62VBajesLJrYPtFm6hcn6c/HkKP7CmKZ5atuzu40m0nifWYsqigR1l9sZGvhhHb/DRshPmiW/0GNrJoA==",
       "requires": {}
     },
     "@iiif/presentation-3": {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "typescript": "^4.9.3"
   },
   "dependencies": {
+    "@iiif/parser": "^1.1.0",
     "@iiif/vault": "^0.9.19",
     "@radix-ui/react-aspect-ratio": "^1.0.1",
     "@samvera/nectar-iiif": "^0.0.18",

--- a/src/components/Figure/Figure.tsx
+++ b/src/components/Figure/Figure.tsx
@@ -32,7 +32,12 @@ const Figure: React.FC<FigureProps> = ({
       <AspectRatio.Root ratio={1 / 1}>
         <Width ref={widthRef} />
         <Placeholder>
-          {thumbnail && <Thumbnail altAsLabel={label} thumbnail={thumbnail} />}
+          {thumbnail && thumbnail.length > 0 && (
+            // TODO: Something here is causing the image not to initiall load
+            // <Thumbnail altAsLabel={label} thumbnail={thumbnail} />
+
+            <img src={thumbnail[0].id} alt="" />
+          )}
         </Placeholder>
       </AspectRatio.Root>
       <figcaption>

--- a/src/components/Items/Item.tsx
+++ b/src/components/Items/Item.tsx
@@ -43,14 +43,19 @@ const Item: React.FC<ItemProps> = ({ index, item }) => {
 
   useEffect(() => {
     if (!item?.thumbnail) return;
-    const thumbnail = vault.get(item.thumbnail);
-    setThumbnail(thumbnail);
+    /** Vault grabs the thumbnail */
+    // const thumbnail = vault.get(item.thumbnail);
+    // setThumbnail(thumbnail);
+
+    /** Grab thumb direct */
+    setThumbnail(item.thumbnail);
   }, []);
 
   const onFocus = () => setIsFocused(true);
   const onBlur = () => setIsFocused(false);
 
   const handleActiveCanvas = (increment: number) => {
+    console.log("handleActiveCanvas");
     if (!manifest) return;
 
     const targetCanvas: number = activeCanvas + increment;

--- a/src/components/Items/Items.tsx
+++ b/src/components/Items/Items.tsx
@@ -46,6 +46,7 @@ const Items: React.FC<ItemsProps> = ({
   items,
 }) => {
   const itemsRef = useRef<HTMLDivElement>(null);
+  console.log("items.length", items.length);
 
   return (
     <ItemsStyled ref={itemsRef}>


### PR DESCRIPTION
Draft PR experimenting with grabbing data directly via `fetch` instead of `vault`.   

- Looks like `vault` helps in it's `get()` method for IIIF data?
- Are we ever interacting with `vault`s data using the wrapping Context's `dispatch()`?
- There seems to be an issue in passing `thumbnail` to `Nectar` going this route, and not sure why.  It's like when `vault` grabs the `thumbnail` via it's `get()`, it plays nicely with how `Nectar`'s `<Thumbnail />` is receiving it?
- In the `@iiif/parser`, trying to find some convenience helpers for parsing/grabbing individual pieces of data...will dig into more mañana.