### PR TITLE
Add error boundaries and additional defensiveness.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@stitches/react": "^1.2.8",
         "react": "^16.13.1  || ^17 || ^18",
         "react-dom": "^16.13.1  || ^17 || ^18",
+        "react-error-boundary": "^3.1.4",
         "swiper": "^8.4.5"
       },
       "devDependencies": {
@@ -6642,6 +6643,21 @@
       },
       "peerDependencies": {
         "react": "^18.2.0"
+      }
+    },
+    "node_modules/react-error-boundary": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-3.1.4.tgz",
+      "integrity": "sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=10",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1"
       }
     },
     "node_modules/react-i18next": {
@@ -13309,6 +13325,14 @@
       "requires": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.0"
+      }
+    },
+    "react-error-boundary": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-3.1.4.tgz",
+      "integrity": "sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==",
+      "requires": {
+        "@babel/runtime": "^7.12.5"
       }
     },
     "react-i18next": {

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "@stitches/react": "^1.2.8",
     "react": "^16.13.1  || ^17 || ^18",
     "react-dom": "^16.13.1  || ^17 || ^18",
+    "react-error-boundary": "^3.1.4",
     "swiper": "^8.4.5"
   },
   "files": [

--- a/src/components/ErrorFallback/ErrorFallback.styled.tsx
+++ b/src/components/ErrorFallback/ErrorFallback.styled.tsx
@@ -1,0 +1,15 @@
+import { styled } from "stitches";
+
+const ErrorFallbackStyled = styled("div", {
+  display: "flex",
+  flexDirection: "column",
+  alignItems: "center",
+});
+
+const Headline = styled("p", {
+  fontWeight: "bold",
+});
+
+const ErrorBody = styled("span", {});
+
+export { ErrorFallbackStyled, ErrorBody, Headline };

--- a/src/components/ErrorFallback/ErrorFallback.test.tsx
+++ b/src/components/ErrorFallback/ErrorFallback.test.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import ErrorFallback from "./ErrorFallback";
+
+describe("ErrorFallback component", () => {
+  const mockErrorObj = {
+    name: "ERROR 123",
+    message: "This is the error message",
+  };
+
+  test("renders the component", () => {
+    render(<ErrorFallback error={mockErrorObj} />);
+    expect(screen.getByRole("alert"));
+  });
+
+  test("displays the error headline and error message", () => {
+    render(<ErrorFallback error={mockErrorObj} />);
+    expect(screen.getByTestId("headline"));
+    expect(screen.getByText(mockErrorObj.message, { exact: false }));
+  });
+});

--- a/src/components/ErrorFallback/ErrorFallback.tsx
+++ b/src/components/ErrorFallback/ErrorFallback.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+import {
+  ErrorFallbackStyled,
+  ErrorBody,
+  Headline,
+} from "./ErrorFallback.styled";
+
+interface ErrorFallbackProps {
+  error: Error;
+}
+
+const ErrorFallback: React.FC<ErrorFallbackProps> = ({ error }) => {
+  const { message } = error;
+
+  return (
+    <ErrorFallbackStyled role="alert">
+      <Headline data-testid="headline">Something went wrong</Headline>
+      {message && <ErrorBody>{`Error message: ${message}`} </ErrorBody>}
+    </ErrorFallbackStyled>
+  );
+};
+
+export default ErrorFallback;

--- a/src/components/Figure/StatusIcon.tsx
+++ b/src/components/Figure/StatusIcon.tsx
@@ -6,13 +6,24 @@ interface StatusProps {
 }
 
 const IconLock = (
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    className="icon-lock"
-    viewBox="0 0 512 512"
-  >
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
     <title>Restricted Item</title>
     <path d="M368 192h-16v-80a96 96 0 10-192 0v80h-16a64.07 64.07 0 00-64 64v176a64.07 64.07 0 0064 64h224a64.07 64.07 0 0064-64V256a64.07 64.07 0 00-64-64zm-48 0H192v-80a64 64 0 11128 0z" />
+  </svg>
+);
+
+const IconUnknown = (
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+    <title>Unknown Status</title>
+    <path
+      d="M160 164s1.44-33 33.54-59.46C212.6 88.83 235.49 84.28 256 84c18.73-.23 35.47 2.94 45.48 7.82C318.59 100.2 352 120.6 352 164c0 45.67-29.18 66.37-62.35 89.18S248 298.36 248 324"
+      fill="none"
+      stroke="currentColor"
+      stroke-linecap="round"
+      stroke-miterlimit="10"
+      stroke-width="40"
+    />
+    <circle cx="248" cy="399.99" r="32" />
   </svg>
 );
 
@@ -23,6 +34,9 @@ const StatusIcon: React.FC<StatusProps> = ({ status }) => {
     switch (status) {
       case 403:
         setIcon(IconLock);
+        break;
+      default:
+        setIcon(IconUnknown);
         break;
     }
   }, [status]);

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -5,6 +5,7 @@ import { Homepage, Label, Summary } from "@samvera/nectar-iiif";
 import { NextIcon } from "components/Icons/NextIcon";
 import { PreviousIcon } from "components/Icons/PrevIcon";
 import { ControlStyled, Icon } from "./Control.styled";
+import ViewAll from "./ViewAll";
 
 interface HeaderProps {
   homepage: ContentResource[];
@@ -58,6 +59,11 @@ const Header: React.FC<HeaderProps> = ({
             <NextIcon />
           </Icon>
         </ControlStyled>
+        {hasHomepage && (
+          <Homepage homepage={homepage} className="bloom-header-homepage">
+            <ViewAll />
+          </Homepage>
+        )}
       </HeaderControls>
     </HeaderStyled>
   );

--- a/src/components/Header/ViewAll.tsx
+++ b/src/components/Header/ViewAll.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+import { styled } from "stitches";
+
+const ViewAllStyled = styled("span", {
+  display: "flex",
+  background: "none",
+  height: "2rem !important",
+  padding: "0 $3",
+  margin: "0 0 0 $3",
+  borderRadius: "2rem",
+  backgroundColor: "$accent",
+  color: "$secondary",
+  cursor: "pointer",
+  boxSizing: "content-box !important",
+  transition: "$all",
+  justifyContent: "center",
+  alignItems: "center",
+  fontSize: "0.8333rem",
+  lineBreak: "none",
+  whiteSpace: "nowrap",
+
+  [`&:hover`]: {
+    backgroundColor: "$accentAlt",
+    boxShadow: "3px 3px 11px #0003",
+
+    [`&:disabled`]: {
+      boxShadow: "unset",
+    },
+  },
+});
+
+const ViewAll = () => {
+  return <ViewAllStyled>View All</ViewAllStyled>;
+};
+
+export default ViewAll;

--- a/src/components/Items/Items.tsx
+++ b/src/components/Items/Items.tsx
@@ -1,6 +1,6 @@
-import React, { useEffect, useRef, useState } from "react";
+import React, { useRef } from "react";
 import { CollectionItems, Collection, Manifest } from "@iiif/presentation-3";
-import { SwiperBreakpoints } from "../../../types/types";
+import { FetchCredentials, SwiperBreakpoints } from "../../../types/types";
 import Item from "./Item";
 import { ItemsStyled } from "./Items.styled";
 import { Navigation, A11y } from "swiper";
@@ -8,6 +8,7 @@ import { Swiper, SwiperSlide } from "swiper/react";
 
 interface ItemsProps {
   breakpoints?: SwiperBreakpoints;
+  credentials: FetchCredentials;
   instance: number;
   items: CollectionItems[];
 }
@@ -42,6 +43,7 @@ const defaultBreakpoints = {
 
 const Items: React.FC<ItemsProps> = ({
   breakpoints = defaultBreakpoints,
+  credentials,
   instance,
   items,
 }) => {
@@ -66,7 +68,11 @@ const Items: React.FC<ItemsProps> = ({
       >
         {items.map((item, index) => (
           <SwiperSlide key={`${item.id}-${index}`}>
-            <Item index={index} item={item as Collection | Manifest} />
+            <Item
+              credentials={credentials}
+              index={index}
+              item={item as Collection | Manifest}
+            />
           </SwiperSlide>
         ))}
       </Swiper>

--- a/src/dev.tsx
+++ b/src/dev.tsx
@@ -4,7 +4,6 @@ import "swiper/css/navigation";
 import "swiper/css/pagination";
 
 import React from "react";
-import ReactDOM from "react-dom";
 import App from "./index";
 import DynamicUrl from "./dev/DynamicUrl";
 import { collections } from "./dev/collections";
@@ -12,12 +11,6 @@ import { createRoot } from "react-dom/client";
 
 const Wrapper = () => {
   const defaultUrl: string = collections[0].url;
-
-  const oneItem =
-    "https://dcapi.rdc-staging.library.northwestern.edu/api/v2/search?query=subject.label:%22Sculpture,%20English--19th%20century%22&collectionLabel=Sculpture,%20English--19th%20century&collectionSummary=Subject&as=iiif";
-
-  const twoItems =
-    "https://dcapi.rdc-staging.library.northwestern.edu/api/v2/search?query=collection.title.keyword:%22Transportation%20Library%20Menu%20Collection%22&collectionLabel=Transportation%20Library%20Menu%20Collection&collectionSummary=Collection&as=iiif";
 
   const [url, setUrl] = React.useState(defaultUrl);
   return (

--- a/src/dev/collections.ts
+++ b/src/dev/collections.ts
@@ -4,12 +4,12 @@ export const collections = [
     label: "Football Films",
   },
   {
-    url: "https://digital.lib.utk.edu/assemble/collection/collections/rfta",
-    label: "Rising from the Ashes",
-  },
-  {
     url: "https://digital.lib.utk.edu/assemble/collection/gsmrc/pcard00",
     label: "Postcards from the Great Smoky Mountains",
+  },
+  {
+    url: "https://digital.lib.utk.edu/assemble/collection/collections/rfta",
+    label: "Rising from the Ashes",
   },
   {
     url: "https://raw.githubusercontent.com/samvera-labs/bloom-iiif/main/public/fixtures/iiif/collection/masks-of-antonio-fava.json",
@@ -26,5 +26,13 @@ export const collections = [
   {
     url: "https://dcapi.rdc-staging.library.northwestern.edu/api/v2/search?query=collection.id:%22b5ba2cce-8b7e-4b8a-ad5c-649dd40637b0%22&collectionLabel=Visibility%20Testing&collectionSummary=Collection&as=iiif",
     label: "Access Demonstration",
+  },
+  {
+    url: "https://dcapi.rdc.library.northwestern.edu/api/v2/search?query=series:%22Berkeley%20Folk%20Music%20Festival%20--%206.%20Festival%20Programs%20&%20Additional%20Operating%20Files%20--%206.3.%20Wild%20West%20Festival%20Operating%20Files%22%20=&collectionLabel=Berkeley%20Folk%20Music%20Festival%20--%206.%20Festival%20Programs%20&%20Additional%20Operating%20Files%20--%206.3.%20Wild%20West%20Festival%20Operating%20Files=&collectionSummary=2%20Items&as=iiif",
+    label: "dev -  bad collection",
+  },
+  {
+    url: "https://dcapi.rdc-staging.library.northwestern.edu/api/v2/works/c483bcc2-a4be-4175-a2d7-b2bcb1e24d28/similar?collectionLabel=More%20Like%20This&collectionSummary=Similar%20to%20null&as=iiif",
+    label: "dev - bad manifest",
   },
 ];

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -13,7 +13,8 @@ import { ConfigOptions } from "../types/types";
 import Header from "components/Header/Header";
 import Items from "components/Items/Items";
 import hash from "lib/hash";
-import { styled } from "stitches";
+import { ErrorBoundary } from "react-error-boundary";
+import ErrorFallback from "components/ErrorFallback/ErrorFallback";
 
 interface BloomProps {
   collectionId: string;
@@ -46,7 +47,9 @@ const Bloom: React.FC<BloomProps> = ({ collectionId, options = {} }) => {
       .loadCollection(collectionId)
       .then((data: any) => setCollection(data))
       .catch((error: any) => {
-        console.error(`Collection failed to load: ${error}`);
+        console.error(
+          `The IIIF Collection ${collectionId} failed to load: ${error}`
+        );
         setError(
           error instanceof Error ? error.message : `Collection failed to load`
         );
@@ -55,37 +58,38 @@ const Bloom: React.FC<BloomProps> = ({ collectionId, options = {} }) => {
   }, [collectionId]);
 
   if (collection?.items.length === 0) {
-    console.log(`The IIIF collection ${collectionId} does not contain items.`);
+    console.log(`The IIIF Collection ${collectionId} does not contain items.`);
     return <></>;
   }
 
   const instance = hash(collectionId);
 
-  if (error)
-    return <p style={{ padding: "1rem" }}>Error loading Collection: {error}</p>;
   if (!collection) return <></>;
 
   return (
-    <StyledBloom>
-      <Header
-        label={collection.label as InternationalString}
-        summary={
-          collection && collection.summary ? collection.summary : { none: [""] }
-        }
-        homepage={collection.homepage as any as ContentResource[]}
-        instance={instance}
-      />
-      <Items
-        items={collection.items as CollectionItems[]}
-        instance={instance}
-        breakpoints={
-          Boolean(options.breakpoints) ? options.breakpoints : undefined
-        }
-      />
-    </StyledBloom>
+    <div>
+      <ErrorBoundary FallbackComponent={ErrorFallback}>
+        <Header
+          label={collection.label as InternationalString}
+          summary={
+            collection && collection.summary
+              ? collection.summary
+              : { none: [""] }
+          }
+          homepage={collection.homepage as any as ContentResource[]}
+          instance={instance}
+        />
+        <Items
+          items={collection.items as CollectionItems[]}
+          instance={instance}
+          breakpoints={
+            Boolean(options.breakpoints) ? options.breakpoints : undefined
+          }
+          credentials={options.credentials ? options.credentials : "omit"}
+        />
+      </ErrorBoundary>
+    </div>
   );
 };
-
-const StyledBloom = styled("div", { padding: "$4 0" });
 
 export default App;

--- a/types/types.ts
+++ b/types/types.ts
@@ -2,6 +2,10 @@ import { SwiperProps } from "swiper/react";
 
 export interface ConfigOptions {
   breakpoints?: SwiperBreakpoints;
+  credentials?: FetchCredentials;
 }
 
 export type SwiperBreakpoints = SwiperProps["breakpoints"];
+
+// https://developer.mozilla.org/en-US/docs/Web/API/fetch#credentials
+export type FetchCredentials = "omit" | "same-origin" | "include";


### PR DESCRIPTION
## What does this do?

This work adds quite a few defensive measures within bloom to prevent various type errors.

1. If a Collection fails to load as a 200, Bloom will now gracefully fail and log the error in the console.
2. If the preview canvas fails to load on hover, Bloom will now not attempt to render the Figure for that canvas. Previously Bloom was attempting to render these a bombing out.
3. Additionally, `credentials` can now be set as an options prop, and `View All` button will render for Collections that a have a `homepage` property.

Note: More work will need to be completed on the dc-nextjs side of things to full complete issue 3420 -- which is happening due to a poorly constructed Collection ID https://dcapi.rdc.library.northwestern.edu/api/v2/search?query=series:%22Berkeley%20Folk%20Music%20Festival%20--%206.%20Festival%20Programs%20&%20Additional%20Operating%20Files%20--%206.3.%20Wild%20West%20Festival%20Operating%20Files%22%20=&collectionLabel=Berkeley%20Folk%20Music%20Festival%20--%206.%20Festival%20Programs%20&%20Additional%20Operating%20Files%20--%206.3.%20Wild%20West%20Festival%20Operating%20Files=&collectionSummary=2%20Items&as=iiif