### PR TITLE
Add enablePreview option.

### DIFF
--- a/src/components/Items/Item.tsx
+++ b/src/components/Items/Item.tsx
@@ -11,17 +11,16 @@ import { Anchor, ItemStyled } from "./Item.styled";
 import Preview from "components/Preview/Preview";
 import { getCanvasResource } from "lib/iiif";
 import Placeholder from "./Placeholder";
-import { FetchCredentials } from "../../../types/types";
 
 interface ItemProps {
-  credentials: FetchCredentials;
   index: number;
   item: Collection | Manifest;
 }
 
-const Item: React.FC<ItemProps> = ({ credentials, index, item }) => {
+const Item: React.FC<ItemProps> = ({ index, item }) => {
   const store = useCollectionState();
-  const { vault } = store;
+  const { vault, options } = store;
+  const { credentials, enablePreview } = options;
 
   const [activeCanvas, setActiveCanvas] = useState<number>(0);
   const [href, setHref] = useState<string>();
@@ -33,7 +32,7 @@ const Item: React.FC<ItemProps> = ({ credentials, index, item }) => {
   const [thumbnail, setThumbnail] = useState<IIIFExternalWebResource[]>([]);
 
   useEffect(() => {
-    isFocused && !manifest
+    enablePreview && isFocused && !manifest
       ? vault
           .load(item.id)
           .then((data: any) => setManifest(data))
@@ -112,12 +111,14 @@ const Item: React.FC<ItemProps> = ({ credentials, index, item }) => {
           status={status}
           thumbnail={thumbnail}
         />
-        <Preview
-          manifest={manifest as Manifest}
-          activeCanvas={activeCanvas}
-          handleActiveCanvas={handleActiveCanvas}
-          isFocused={isFocused}
-        />
+        {enablePreview && (
+          <Preview
+            manifest={manifest as Manifest}
+            activeCanvas={activeCanvas}
+            handleActiveCanvas={handleActiveCanvas}
+            isFocused={isFocused}
+          />
+        )}
       </Anchor>
     </ItemStyled>
   );

--- a/src/components/Items/Items.tsx
+++ b/src/components/Items/Items.tsx
@@ -1,6 +1,6 @@
 import React, { useRef } from "react";
 import { CollectionItems, Collection, Manifest } from "@iiif/presentation-3";
-import { FetchCredentials, SwiperBreakpoints } from "../../../types/types";
+import { SwiperBreakpoints } from "../../types/types";
 import Item from "./Item";
 import { ItemsStyled } from "./Items.styled";
 import { Navigation, A11y } from "swiper";
@@ -8,7 +8,6 @@ import { Swiper, SwiperSlide } from "swiper/react";
 
 interface ItemsProps {
   breakpoints?: SwiperBreakpoints;
-  credentials: FetchCredentials;
   instance: number;
   items: CollectionItems[];
 }
@@ -43,7 +42,6 @@ const defaultBreakpoints = {
 
 const Items: React.FC<ItemsProps> = ({
   breakpoints = defaultBreakpoints,
-  credentials,
   instance,
   items,
 }) => {
@@ -72,11 +70,7 @@ const Items: React.FC<ItemsProps> = ({
             data-index={index}
             data-type={item?.type.toLowerCase()}
           >
-            <Item
-              credentials={credentials}
-              index={index}
-              item={item as Collection | Manifest}
-            />
+            <Item index={index} item={item as Collection | Manifest} />
           </SwiperSlide>
         ))}
       </Swiper>

--- a/src/context/collection-context.tsx
+++ b/src/context/collection-context.tsx
@@ -1,8 +1,10 @@
 import React from "react";
 import { Vault } from "@iiif/vault";
+import { ConfigOptions } from "../types/types";
 
 interface CollectionContextStore {
   isLoaded: boolean;
+  options: ConfigOptions;
   vault: Vault;
 }
 
@@ -11,8 +13,12 @@ interface CollectionAction {
   isLoaded: boolean;
 }
 
-const defaultState: CollectionContextStore = {
+export const defaultState: CollectionContextStore = {
   isLoaded: false,
+  options: {
+    enablePreview: false,
+    credentials: "omit",
+  },
   vault: new Vault(),
 };
 

--- a/src/dev/collections.ts
+++ b/src/dev/collections.ts
@@ -1,7 +1,7 @@
 export const collections = [
   {
-    url: "https://raw.githubusercontent.com/samvera-labs/bloom-iiif/main/public/fixtures/iiif/collection/athletic-department-footbal-films.json",
-    label: "Football Films",
+    url: "https://raw.githubusercontent.com/samvera-labs/bloom-iiif/main/public/fixtures/iiif/collection/masks-of-antonio-fava.json",
+    label: "Masks of Antonio Fava",
   },
   {
     url: "https://digital.lib.utk.edu/assemble/collection/gsmrc/pcard00",
@@ -10,10 +10,6 @@ export const collections = [
   {
     url: "https://digital.lib.utk.edu/assemble/collection/collections/rfta",
     label: "Rising from the Ashes",
-  },
-  {
-    url: "https://raw.githubusercontent.com/samvera-labs/bloom-iiif/main/public/fixtures/iiif/collection/masks-of-antonio-fava.json",
-    label: "Masks of Antonio Fava",
   },
   {
     url: "https://iiif.bodleian.ox.ac.uk/iiif/collection/flora-and-fauna-graeca",

--- a/src/dev/collections.ts
+++ b/src/dev/collections.ts
@@ -1,6 +1,6 @@
 export const collections = [
   {
-    url: "https://raw.githubusercontent.com/samvera-labs/bloom-iiif/main/public/fixtures/iiif/collection/masks-of-antonio-fava.json",
+    url: "https://api.dc.library.northwestern.edu/api/v2/collections/c373ecd2-2c45-45f2-9f9e-52dc244870bd?as=iiif",
     label: "Masks of Antonio Fava",
   },
   {
@@ -8,27 +8,27 @@ export const collections = [
     label: "Postcards from the Great Smoky Mountains",
   },
   {
-    url: "https://digital.lib.utk.edu/assemble/collection/collections/rfta",
-    label: "Rising from the Ashes",
-  },
-  {
     url: "https://iiif.bodleian.ox.ac.uk/iiif/collection/flora-and-fauna-graeca",
     label: "Flora and Fauna Graeca",
+  },
+  {
+    url: "https://api.dc.library.northwestern.edu/api/v2/collections/b46c9cf7-0e49-4993-9e0e-3cda030c4439?as=iiif&size=100",
+    label: "Charlotte Moorman Archive",
+  },
+  {
+    url: "https://canopy-iiif.vercel.app/api/facet/date/1910",
+    label: "Canopy IIIF - 1910 (Date)",
   },
   {
     url: "https://figgy.princeton.edu/concern/scanned_resources/8b73b1bb-6417-4ae1-b516-bb68d999ed2f/manifest",
     label: "Clarissa",
   },
   {
-    url: "https://dcapi.rdc-staging.library.northwestern.edu/api/v2/search?query=collection.id:%22b5ba2cce-8b7e-4b8a-ad5c-649dd40637b0%22&collectionLabel=Visibility%20Testing&collectionSummary=Collection&as=iiif",
-    label: "Access Demonstration",
+    url: "https://digital.lib.utk.edu/assemble/collection/collections/rfta",
+    label: "Rising from the Ashes",
   },
   {
-    url: "https://dcapi.rdc.library.northwestern.edu/api/v2/search?query=series:%22Berkeley%20Folk%20Music%20Festival%20--%206.%20Festival%20Programs%20&%20Additional%20Operating%20Files%20--%206.3.%20Wild%20West%20Festival%20Operating%20Files%22%20=&collectionLabel=Berkeley%20Folk%20Music%20Festival%20--%206.%20Festival%20Programs%20&%20Additional%20Operating%20Files%20--%206.3.%20Wild%20West%20Festival%20Operating%20Files=&collectionSummary=2%20Items&as=iiif",
-    label: "dev -  bad collection",
-  },
-  {
-    url: "https://dcapi.rdc-staging.library.northwestern.edu/api/v2/works/c483bcc2-a4be-4175-a2d7-b2bcb1e24d28/similar?collectionLabel=More%20Like%20This&collectionSummary=Similar%20to%20null&as=iiif",
-    label: "dev - bad manifest",
+    url: 'https://api.dc.library.northwestern.edu/api/v2/search?query=%22Joan%20Baez%22&collectionLabel=Joan Baez&collectionSummary=Search results for "Joan Baez" (Page 3)&as=iiif&size=40&page=3',
+    label: "Joan Baez (Search Results)",
   },
 ];

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,9 +7,10 @@ import {
 } from "@iiif/presentation-3";
 import {
   CollectionProvider,
+  defaultState,
   useCollectionState,
 } from "context/collection-context";
-import { ConfigOptions } from "../types/types";
+import { ConfigOptions } from "./types/types";
 import Header from "components/Header/Header";
 import Items from "components/Items/Items";
 import hash from "lib/hash";
@@ -22,27 +23,24 @@ interface BloomProps {
 }
 
 const App: React.FC<BloomProps> = (props) => (
-  <CollectionProvider>
+  <CollectionProvider
+    initialState={{
+      ...defaultState,
+      options: { ...props.options },
+    }}
+  >
     <Bloom {...props} />
   </CollectionProvider>
 );
 
-const Bloom: React.FC<BloomProps> = ({ collectionId, options = {} }) => {
+const Bloom: React.FC<BloomProps> = ({ collectionId }) => {
   const store = useCollectionState();
-  const { vault } = store;
+  const { vault, options } = store;
   const [collection, setCollection] = useState<CollectionNormalized>();
   const [error, setError] = useState("");
 
-  /**
-   * todo: add wrapping context and store vault
-   */
   useEffect(() => {
     if (!collectionId) return;
-
-    /**
-     * load collection using @iiif/vault
-     */
-
     vault
       .loadCollection(collectionId)
       .then((data: any) => setCollection(data))
@@ -82,10 +80,7 @@ const Bloom: React.FC<BloomProps> = ({ collectionId, options = {} }) => {
         <Items
           items={collection.items as CollectionItems[]}
           instance={instance}
-          breakpoints={
-            Boolean(options.breakpoints) ? options.breakpoints : undefined
-          }
-          credentials={options.credentials ? options.credentials : "omit"}
+          breakpoints={options.breakpoints}
         />
       </ErrorBoundary>
     </div>

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -3,6 +3,7 @@ import { SwiperProps } from "swiper/react";
 export interface ConfigOptions {
   breakpoints?: SwiperBreakpoints;
   credentials?: FetchCredentials;
+  enablePreview?: boolean;
 }
 
 export type SwiperBreakpoints = SwiperProps["breakpoints"];


### PR DESCRIPTION
## What does this do?

This PR does two primary things:

- Adds functionality to render the Preview overlay and allow for hover/focus events to request manifest through a new `enablePreview` property. This property is part of the ConfigOptions `options` prop set on the Bloom component. By default it is `false`.
- Rewires the `options` to funnel through our wrapping Context. At this point the prop drilling was getting out of hand, so working from some higher level state for these sorts of config options should make our life easier. 

**Note:** I also took some time to update examples to use our new `?as=iiif` endpoints in the DC API v2.

## How should we review?
Take a look, everything should be pretty solid as far as the options and context. 

Try enabled/disabling the new enablePreview option by updating dev.tsx: 
```jsx
<App collectionId={url} options={{ enablePreview: true }} key={url} />
```