### PR TITLE
Add status icon for 403 resources.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,7 @@
       "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
-        "@iiif/vault": "^0.9.19",
-        "@iiif/vault-helpers": "^0.9.11",
+        "@iiif/parser": "^1.1.2",
         "@radix-ui/react-aspect-ratio": "^1.0.1",
         "@samvera/nectar-iiif": "^0.0.18",
         "@stitches/react": "^1.2.8",
@@ -59,16 +58,6 @@
       },
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@atlas-viewer/iiif-image-api": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@atlas-viewer/iiif-image-api/-/iiif-image-api-2.0.7.tgz",
-      "integrity": "sha512-xwKyXyAXOtrU1K/8FYdIMuaLgg9/6gkB4YcohojZTEnsKdyNdVyOi/neiL8dqXeZZo0ZdBB2VDZtrxqkoU2ZWQ==",
-      "peer": true,
-      "dependencies": {
-        "@iiif/presentation-3": "*",
-        "node-fetch": "^3.2.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -708,19 +697,19 @@
       }
     },
     "node_modules/@iiif/parser": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/@iiif/parser/-/parser-1.0.10.tgz",
-      "integrity": "sha512-z8b8a02ltoBoKGetfyM4rqIXQ+gnE5rjGXKqzZwvWSAN0hnzA5nghTqisogYo0bQx3ct/Q1bIysvpMMR64uIUQ==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@iiif/parser/-/parser-1.1.2.tgz",
+      "integrity": "sha512-yjbhSWBB+cWHjAgeWlMYgNydMxDGU1BO3JnmgxCclMcfi59JDsKHMXpgZpCNw+svcirBtIMD2u70KPFinr2pUA==",
       "dependencies": {
-        "@iiif/presentation-2": "^1.0.1",
-        "@iiif/presentation-3": "^1.0.4",
+        "@iiif/presentation-2": "^1.0.4",
+        "@iiif/presentation-3": "^1.1.3",
         "@types/geojson": "^7946.0.8"
       }
     },
     "node_modules/@iiif/presentation-2": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@iiif/presentation-2/-/presentation-2-1.0.1.tgz",
-      "integrity": "sha512-iWF6rgAi9ksSwbH/4uJW1/49DOL1wN2mLKovu0qy1GYtCTg42bryAxYtnBsw6LrJZWykTStv7R3DynChfECmnA==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@iiif/presentation-2/-/presentation-2-1.0.4.tgz",
+      "integrity": "sha512-hJakpq62VBajesLJrYPtFm6hcn6c/HkKP7CmKZ5atuzu40m0nifWYsqigR1l9sZGvhhHb/DRshPmiW/0GNrJoA==",
       "peerDependencies": {
         "@iiif/presentation-3": "*"
       }
@@ -731,40 +720,6 @@
       "integrity": "sha512-Ek+25nkQouo0pXAqCsWYbAeS4jLDEBQA7iul2jzgnvoJrucxDQN2lXyNLgOUDRqpTdSqJ69iz5lm6DLaxil+Nw==",
       "dependencies": {
         "@types/geojson": "^7946.0.7"
-      }
-    },
-    "node_modules/@iiif/vault": {
-      "version": "0.9.19",
-      "resolved": "https://registry.npmjs.org/@iiif/vault/-/vault-0.9.19.tgz",
-      "integrity": "sha512-YoRp4waV1mGMOJaaTpzn/YnZKRnHZdbXwCt2LbCA89CZhtlTh6QUhs04KWNrGxrxnk/Wtt67/U4SyZgD10g0NQ==",
-      "dependencies": {
-        "@iiif/parser": "1.*",
-        "@iiif/presentation-2": "1.*",
-        "@iiif/presentation-3": "1.*",
-        "mitt": "^3.0.0",
-        "node-fetch": "^3.1.1",
-        "redux": "^4.1.2",
-        "tiny-invariant": "^1.2.0",
-        "typesafe-actions": "^5.1.0"
-      }
-    },
-    "node_modules/@iiif/vault-helpers": {
-      "version": "0.9.11",
-      "resolved": "https://registry.npmjs.org/@iiif/vault-helpers/-/vault-helpers-0.9.11.tgz",
-      "integrity": "sha512-4XuFPvu233mMzfU/mMpAqFY5aCTzwhJ0u7MzPcpN8nSfMwbV5Dyvv0PppjcocvbWMUUXScqerRoB1MAfSFas6w==",
-      "dependencies": {
-        "@iiif/presentation-2": "1.x",
-        "@iiif/presentation-3": "1.x"
-      },
-      "optionalDependencies": {
-        "abs-svg-path": "^0.1.0",
-        "parse-svg-path": "^0.1.0",
-        "react-i18next": "^11.18.0",
-        "svg-arc-to-cubic-bezier": "^3.2.0"
-      },
-      "peerDependencies": {
-        "@atlas-viewer/iiif-image-api": "2.x",
-        "@iiif/vault": "0.9.x"
       }
     },
     "node_modules/@istanbuljs/load-nyc-config": {
@@ -1622,12 +1577,6 @@
       "integrity": "sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==",
       "dev": true
     },
-    "node_modules/abs-svg-path": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/abs-svg-path/-/abs-svg-path-0.1.1.tgz",
-      "integrity": "sha512-d8XPSGjfyzlXC3Xx891DJRyZfqk5JU0BJrDQcsWomFIV1/BIzPW5HDH5iDdWpqWaav0YVIEzT1RHTwWr0FFshA==",
-      "optional": true
-    },
     "node_modules/accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -2442,14 +2391,6 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.0.tgz",
       "integrity": "sha512-uX1KG+x9h5hIJsaKR9xHUeUraxf8IODOwq9JLNPq6BwB04a/xgpq3rcx47l5BZu5zBPlgD342tdke3Hom/nJRA==",
       "dev": true
-    },
-    "node_modules/data-uri-to-buffer": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.0.tgz",
-      "integrity": "sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA==",
-      "engines": {
-        "node": ">= 12"
-      }
     },
     "node_modules/debug": {
       "version": "4.3.4",
@@ -3312,28 +3253,6 @@
         "bser": "2.1.1"
       }
     },
-    "node_modules/fetch-blob": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.1.5.tgz",
-      "integrity": "sha512-N64ZpKqoLejlrwkIAnb9iLSA3Vx/kjgzpcDhygcqJ2KKjky8nCgUQ+dzXtbrLaWZGZNmNfQTsiQ0weZ1svglHg==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "dependencies": {
-        "node-domexception": "^1.0.0",
-        "web-streams-polyfill": "^3.0.3"
-      },
-      "engines": {
-        "node": "^12.20 || >= 14.13"
-      }
-    },
     "node_modules/file-uri-to-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
@@ -3406,17 +3325,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/formdata-polyfill": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
-      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
-      "dependencies": {
-        "fetch-blob": "^3.1.2"
-      },
-      "engines": {
-        "node": ">=12.20.0"
       }
     },
     "node_modules/fragment-cache": {
@@ -3664,15 +3572,6 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
     },
-    "node_modules/html-parse-stringify": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
-      "integrity": "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==",
-      "optional": true,
-      "dependencies": {
-        "void-elements": "3.1.0"
-      }
-    },
     "node_modules/htmlparser2": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",
@@ -3744,30 +3643,6 @@
       "dev": true,
       "engines": {
         "node": ">=10.17.0"
-      }
-    },
-    "node_modules/i18next": {
-      "version": "22.1.4",
-      "resolved": "https://registry.npmjs.org/i18next/-/i18next-22.1.4.tgz",
-      "integrity": "sha512-MCDtNRyovLY22rgLoZdCzg2QIza1V1A/3Hxb99akJzTDjcqCRWEsglTpFUt0vUjOxSxz+WmxmFETLHORRS+n6Q==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://locize.com"
-        },
-        {
-          "type": "individual",
-          "url": "https://locize.com/i18next.html"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
-        }
-      ],
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@babel/runtime": "^7.20.6"
       }
     },
     "node_modules/import-local": {
@@ -5912,11 +5787,6 @@
         "node": "*"
       }
     },
-    "node_modules/mitt": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.0.tgz",
-      "integrity": "sha512-7dX2/10ITVyqh4aOSVI9gdape+t9l2/8QxHrFmUXu4EEUpdlxl6RudZUPZoc+zuY2hk1j7XxVroIVIan/pD/SQ=="
-    },
     "node_modules/mixin-deep": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
@@ -6143,41 +6013,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/node-domexception": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "github",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "engines": {
-        "node": ">=10.5.0"
-      }
-    },
-    "node_modules/node-fetch": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.2.6.tgz",
-      "integrity": "sha512-LAy/HZnLADOVkVPubaxHDft29booGglPFDr2Hw0J1AercRh01UiVFm++KMDnJeH9sHgNB4hsXPii7Sgym/sTbw==",
-      "dependencies": {
-        "data-uri-to-buffer": "^4.0.0",
-        "fetch-blob": "^3.1.4",
-        "formdata-polyfill": "^4.0.10"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/node-fetch"
-      }
-    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -6401,12 +6236,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/parse-srcset/-/parse-srcset-1.0.2.tgz",
       "integrity": "sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q=="
-    },
-    "node_modules/parse-svg-path": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/parse-svg-path/-/parse-svg-path-0.1.2.tgz",
-      "integrity": "sha512-JyPSBnkTJ0AI8GGJLfMXvKq42cj5c006fnLz6fXy6zfoVjJizi8BNTpu8on8ziI1cKy9d9DGNuY17Ce7wuejpQ==",
-      "optional": true
     },
     "node_modules/parseurl": {
       "version": "1.3.3",
@@ -6660,28 +6489,6 @@
         "react": ">=16.13.1"
       }
     },
-    "node_modules/react-i18next": {
-      "version": "11.18.6",
-      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-11.18.6.tgz",
-      "integrity": "sha512-yHb2F9BiT0lqoQDt8loZ5gWP331GwctHz9tYQ8A2EIEUu+CcEdjBLQWli1USG3RdWQt3W+jqQLg/d4rrQR96LA==",
-      "optional": true,
-      "dependencies": {
-        "@babel/runtime": "^7.14.5",
-        "html-parse-stringify": "^3.0.1"
-      },
-      "peerDependencies": {
-        "i18next": ">= 19.0.0",
-        "react": ">= 16.8.0"
-      },
-      "peerDependenciesMeta": {
-        "react-dom": {
-          "optional": true
-        },
-        "react-native": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -6726,14 +6533,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/redux": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.0.tgz",
-      "integrity": "sha512-oSBmcKKIuIR4ME29/AeNUnl5L+hvBq7OaJWzaptTQJAntaPvxIJqfnjbaEiCzzaIz+XmVILfqAM3Ob0aXLPfjA==",
-      "dependencies": {
-        "@babel/runtime": "^7.9.2"
       }
     },
     "node_modules/regenerator-runtime": {
@@ -7594,12 +7393,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/svg-arc-to-cubic-bezier": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/svg-arc-to-cubic-bezier/-/svg-arc-to-cubic-bezier-3.2.0.tgz",
-      "integrity": "sha512-djbJ/vZKZO+gPoSDThGNpKDO+o+bAeA4XQKovvkNCqnIS2t+S4qnLAGQhyyrulhCFRl1WWzAp0wUDV8PpTVU3g==",
-      "optional": true
-    },
     "node_modules/swiper": {
       "version": "8.4.5",
       "resolved": "https://registry.npmjs.org/swiper/-/swiper-8.4.5.tgz",
@@ -7642,11 +7435,6 @@
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
       "dev": true
-    },
-    "node_modules/tiny-invariant": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.2.0.tgz",
-      "integrity": "sha512-1Uhn/aqw5C6RI4KejVeTg6mIS7IqxnLJ8Mv2tV5rTc0qWobay7pDUz6Wi392Cnc8ak1H0F2cjoRzb2/AW4+Fvg=="
     },
     "node_modules/tmpl": {
       "version": "1.0.5",
@@ -7942,14 +7730,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/typesafe-actions": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/typesafe-actions/-/typesafe-actions-5.1.0.tgz",
-      "integrity": "sha512-bna6Yi1pRznoo6Bz1cE6btB/Yy8Xywytyfrzu/wc+NFW3ZF0I+2iCGImhBsoYYCOWuICtRO4yHcnDlzgo1AdNg==",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
     "node_modules/typescript": {
       "version": "4.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.3.tgz",
@@ -8168,15 +7948,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/void-elements": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
-      "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
-      "optional": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/vscode-oniguruma": {
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.6.2.tgz",
@@ -8196,14 +7967,6 @@
       "dev": true,
       "dependencies": {
         "makeerror": "1.0.12"
-      }
-    },
-    "node_modules/web-streams-polyfill": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
-      "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==",
-      "engines": {
-        "node": ">= 8"
       }
     },
     "node_modules/websocket-driver": {
@@ -8359,16 +8122,6 @@
       "requires": {
         "@jridgewell/gen-mapping": "^0.1.0",
         "@jridgewell/trace-mapping": "^0.3.9"
-      }
-    },
-    "@atlas-viewer/iiif-image-api": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@atlas-viewer/iiif-image-api/-/iiif-image-api-2.0.7.tgz",
-      "integrity": "sha512-xwKyXyAXOtrU1K/8FYdIMuaLgg9/6gkB4YcohojZTEnsKdyNdVyOi/neiL8dqXeZZo0ZdBB2VDZtrxqkoU2ZWQ==",
-      "peer": true,
-      "requires": {
-        "@iiif/presentation-3": "*",
-        "node-fetch": "^3.2.0"
       }
     },
     "@babel/code-frame": {
@@ -8847,19 +8600,19 @@
       "optional": true
     },
     "@iiif/parser": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/@iiif/parser/-/parser-1.0.10.tgz",
-      "integrity": "sha512-z8b8a02ltoBoKGetfyM4rqIXQ+gnE5rjGXKqzZwvWSAN0hnzA5nghTqisogYo0bQx3ct/Q1bIysvpMMR64uIUQ==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@iiif/parser/-/parser-1.1.2.tgz",
+      "integrity": "sha512-yjbhSWBB+cWHjAgeWlMYgNydMxDGU1BO3JnmgxCclMcfi59JDsKHMXpgZpCNw+svcirBtIMD2u70KPFinr2pUA==",
       "requires": {
-        "@iiif/presentation-2": "^1.0.1",
-        "@iiif/presentation-3": "^1.0.4",
+        "@iiif/presentation-2": "^1.0.4",
+        "@iiif/presentation-3": "^1.1.3",
         "@types/geojson": "^7946.0.8"
       }
     },
     "@iiif/presentation-2": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@iiif/presentation-2/-/presentation-2-1.0.1.tgz",
-      "integrity": "sha512-iWF6rgAi9ksSwbH/4uJW1/49DOL1wN2mLKovu0qy1GYtCTg42bryAxYtnBsw6LrJZWykTStv7R3DynChfECmnA==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@iiif/presentation-2/-/presentation-2-1.0.4.tgz",
+      "integrity": "sha512-hJakpq62VBajesLJrYPtFm6hcn6c/HkKP7CmKZ5atuzu40m0nifWYsqigR1l9sZGvhhHb/DRshPmiW/0GNrJoA==",
       "requires": {}
     },
     "@iiif/presentation-3": {
@@ -8868,34 +8621,6 @@
       "integrity": "sha512-Ek+25nkQouo0pXAqCsWYbAeS4jLDEBQA7iul2jzgnvoJrucxDQN2lXyNLgOUDRqpTdSqJ69iz5lm6DLaxil+Nw==",
       "requires": {
         "@types/geojson": "^7946.0.7"
-      }
-    },
-    "@iiif/vault": {
-      "version": "0.9.19",
-      "resolved": "https://registry.npmjs.org/@iiif/vault/-/vault-0.9.19.tgz",
-      "integrity": "sha512-YoRp4waV1mGMOJaaTpzn/YnZKRnHZdbXwCt2LbCA89CZhtlTh6QUhs04KWNrGxrxnk/Wtt67/U4SyZgD10g0NQ==",
-      "requires": {
-        "@iiif/parser": "1.*",
-        "@iiif/presentation-2": "1.*",
-        "@iiif/presentation-3": "1.*",
-        "mitt": "^3.0.0",
-        "node-fetch": "^3.1.1",
-        "redux": "^4.1.2",
-        "tiny-invariant": "^1.2.0",
-        "typesafe-actions": "^5.1.0"
-      }
-    },
-    "@iiif/vault-helpers": {
-      "version": "0.9.11",
-      "resolved": "https://registry.npmjs.org/@iiif/vault-helpers/-/vault-helpers-0.9.11.tgz",
-      "integrity": "sha512-4XuFPvu233mMzfU/mMpAqFY5aCTzwhJ0u7MzPcpN8nSfMwbV5Dyvv0PppjcocvbWMUUXScqerRoB1MAfSFas6w==",
-      "requires": {
-        "@iiif/presentation-2": "1.x",
-        "@iiif/presentation-3": "1.x",
-        "abs-svg-path": "^0.1.0",
-        "parse-svg-path": "^0.1.0",
-        "react-i18next": "^11.18.0",
-        "svg-arc-to-cubic-bezier": "^3.2.0"
       }
     },
     "@istanbuljs/load-nyc-config": {
@@ -9611,12 +9336,6 @@
       "integrity": "sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==",
       "dev": true
     },
-    "abs-svg-path": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/abs-svg-path/-/abs-svg-path-0.1.1.tgz",
-      "integrity": "sha512-d8XPSGjfyzlXC3Xx891DJRyZfqk5JU0BJrDQcsWomFIV1/BIzPW5HDH5iDdWpqWaav0YVIEzT1RHTwWr0FFshA==",
-      "optional": true
-    },
     "accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -10235,11 +9954,6 @@
       "integrity": "sha512-uX1KG+x9h5hIJsaKR9xHUeUraxf8IODOwq9JLNPq6BwB04a/xgpq3rcx47l5BZu5zBPlgD342tdke3Hom/nJRA==",
       "dev": true
     },
-    "data-uri-to-buffer": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.0.tgz",
-      "integrity": "sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA=="
-    },
     "debug": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -10794,15 +10508,6 @@
         "bser": "2.1.1"
       }
     },
-    "fetch-blob": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.1.5.tgz",
-      "integrity": "sha512-N64ZpKqoLejlrwkIAnb9iLSA3Vx/kjgzpcDhygcqJ2KKjky8nCgUQ+dzXtbrLaWZGZNmNfQTsiQ0weZ1svglHg==",
-      "requires": {
-        "node-domexception": "^1.0.0",
-        "web-streams-polyfill": "^3.0.3"
-      }
-    },
     "file-uri-to-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
@@ -10866,14 +10571,6 @@
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
       "integrity": "sha512-7EwmXrOjyL+ChxMhmG5lnW9MPt1aIeZEwKhQzoBUdTV0N3zuwWDZYVJatDvZ2OyzPUvdIAZDsCetk3coyMfcnQ==",
       "dev": true
-    },
-    "formdata-polyfill": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
-      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
-      "requires": {
-        "fetch-blob": "^3.1.2"
-      }
     },
     "fragment-cache": {
       "version": "0.2.1",
@@ -11060,15 +10757,6 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
     },
-    "html-parse-stringify": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
-      "integrity": "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==",
-      "optional": true,
-      "requires": {
-        "void-elements": "3.1.0"
-      }
-    },
     "htmlparser2": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",
@@ -11124,16 +10812,6 @@
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
       "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
       "dev": true
-    },
-    "i18next": {
-      "version": "22.1.4",
-      "resolved": "https://registry.npmjs.org/i18next/-/i18next-22.1.4.tgz",
-      "integrity": "sha512-MCDtNRyovLY22rgLoZdCzg2QIza1V1A/3Hxb99akJzTDjcqCRWEsglTpFUt0vUjOxSxz+WmxmFETLHORRS+n6Q==",
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "@babel/runtime": "^7.20.6"
-      }
     },
     "import-local": {
       "version": "3.1.0",
@@ -12787,11 +12465,6 @@
         "brace-expansion": "^1.1.7"
       }
     },
-    "mitt": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.0.tgz",
-      "integrity": "sha512-7dX2/10ITVyqh4aOSVI9gdape+t9l2/8QxHrFmUXu4EEUpdlxl6RudZUPZoc+zuY2hk1j7XxVroIVIan/pD/SQ=="
-    },
     "mixin-deep": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
@@ -12976,21 +12649,6 @@
       "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
       "dev": true
     },
-    "node-domexception": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="
-    },
-    "node-fetch": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.2.6.tgz",
-      "integrity": "sha512-LAy/HZnLADOVkVPubaxHDft29booGglPFDr2Hw0J1AercRh01UiVFm++KMDnJeH9sHgNB4hsXPii7Sgym/sTbw==",
-      "requires": {
-        "data-uri-to-buffer": "^4.0.0",
-        "fetch-blob": "^3.1.4",
-        "formdata-polyfill": "^4.0.10"
-      }
-    },
     "node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -13157,12 +12815,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/parse-srcset/-/parse-srcset-1.0.2.tgz",
       "integrity": "sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q=="
-    },
-    "parse-svg-path": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/parse-svg-path/-/parse-svg-path-0.1.2.tgz",
-      "integrity": "sha512-JyPSBnkTJ0AI8GGJLfMXvKq42cj5c006fnLz6fXy6zfoVjJizi8BNTpu8on8ziI1cKy9d9DGNuY17Ce7wuejpQ==",
-      "optional": true
     },
     "parseurl": {
       "version": "1.3.3",
@@ -13335,16 +12987,6 @@
         "@babel/runtime": "^7.12.5"
       }
     },
-    "react-i18next": {
-      "version": "11.18.6",
-      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-11.18.6.tgz",
-      "integrity": "sha512-yHb2F9BiT0lqoQDt8loZ5gWP331GwctHz9tYQ8A2EIEUu+CcEdjBLQWli1USG3RdWQt3W+jqQLg/d4rrQR96LA==",
-      "optional": true,
-      "requires": {
-        "@babel/runtime": "^7.14.5",
-        "html-parse-stringify": "^3.0.1"
-      }
-    },
     "react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -13383,14 +13025,6 @@
       "requires": {
         "indent-string": "^4.0.0",
         "strip-indent": "^3.0.0"
-      }
-    },
-    "redux": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.0.tgz",
-      "integrity": "sha512-oSBmcKKIuIR4ME29/AeNUnl5L+hvBq7OaJWzaptTQJAntaPvxIJqfnjbaEiCzzaIz+XmVILfqAM3Ob0aXLPfjA==",
-      "requires": {
-        "@babel/runtime": "^7.9.2"
       }
     },
     "regenerator-runtime": {
@@ -14091,12 +13725,6 @@
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
       "dev": true
     },
-    "svg-arc-to-cubic-bezier": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/svg-arc-to-cubic-bezier/-/svg-arc-to-cubic-bezier-3.2.0.tgz",
-      "integrity": "sha512-djbJ/vZKZO+gPoSDThGNpKDO+o+bAeA4XQKovvkNCqnIS2t+S4qnLAGQhyyrulhCFRl1WWzAp0wUDV8PpTVU3g==",
-      "optional": true
-    },
     "swiper": {
       "version": "8.4.5",
       "resolved": "https://registry.npmjs.org/swiper/-/swiper-8.4.5.tgz",
@@ -14122,11 +13750,6 @@
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
       "dev": true
-    },
-    "tiny-invariant": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.2.0.tgz",
-      "integrity": "sha512-1Uhn/aqw5C6RI4KejVeTg6mIS7IqxnLJ8Mv2tV5rTc0qWobay7pDUz6Wi392Cnc8ak1H0F2cjoRzb2/AW4+Fvg=="
     },
     "tmpl": {
       "version": "1.0.5",
@@ -14322,11 +13945,6 @@
       "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
       "dev": true
     },
-    "typesafe-actions": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/typesafe-actions/-/typesafe-actions-5.1.0.tgz",
-      "integrity": "sha512-bna6Yi1pRznoo6Bz1cE6btB/Yy8Xywytyfrzu/wc+NFW3ZF0I+2iCGImhBsoYYCOWuICtRO4yHcnDlzgo1AdNg=="
-    },
     "typescript": {
       "version": "4.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.3.tgz",
@@ -14486,12 +14104,6 @@
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
       "dev": true
     },
-    "void-elements": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
-      "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
-      "optional": true
-    },
     "vscode-oniguruma": {
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.6.2.tgz",
@@ -14512,11 +14124,6 @@
       "requires": {
         "makeerror": "1.0.12"
       }
-    },
-    "web-streams-polyfill": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
-      "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q=="
     },
     "websocket-driver": {
       "version": "0.7.4",

--- a/package.json
+++ b/package.json
@@ -50,8 +50,7 @@
     "typescript": "^4.9.3"
   },
   "dependencies": {
-    "@iiif/vault": "^0.9.19",
-    "@iiif/vault-helpers": "^0.9.11",
+    "@iiif/parser": "^1.1.2",
     "@radix-ui/react-aspect-ratio": "^1.0.1",
     "@samvera/nectar-iiif": "^0.0.18",
     "@stitches/react": "^1.2.8",

--- a/public/fixtures/iiif/collection/mixed-access.json
+++ b/public/fixtures/iiif/collection/mixed-access.json
@@ -1,0 +1,341 @@
+{
+  "@context": ["http://iiif.io/api/presentation/3/context.json"],
+  "id": "http://127.0.0.1:8080/fixtures/iiif/collection/mixed-access.json",
+  "type": "Collection",
+  "label": {
+    "none": ["IIIF Collection"]
+  },
+  "summary": {
+    "none": [""]
+  },
+  "homepage": [
+    {
+      "id": "https://dc.library.northwestern.edu/search?q=assembly",
+      "type": "Text",
+      "format": "text/html",
+      "label": {
+        "none": ["IIIF Collection"]
+      }
+    }
+  ],
+  "items": [
+    {
+      "id": "https://api.dc.library.northwestern.edu/api/v2/works/cfeddfe9-5aae-4772-933e-99d91451276e?as=iiif",
+      "type": "Manifest",
+      "homepage": [
+        {
+          "id": "https://dc.library.northwestern.edu/items/cfeddfe9-5aae-4772-933e-99d91451276e",
+          "type": "Text",
+          "format": "text/html",
+          "label": {
+            "none": ["Project Survival Teach-out. Parts 2, 3, 4, and 5"]
+          }
+        }
+      ],
+      "label": {
+        "none": ["Project Survival Teach-out. Parts 2, 3, 4, and 5"]
+      },
+      "summary": {
+        "none": ["Video"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://api.dc.library.northwestern.edu/api/v2/works/cfeddfe9-5aae-4772-933e-99d91451276e/thumbnail",
+          "format": "image/jpeg",
+          "type": "Image",
+          "width": 400,
+          "height": 400
+        }
+      ]
+    },
+    {
+      "id": "https://api.dc.library.northwestern.edu/api/v2/works/c4b05936-2202-4d52-b7ab-9d02480c6c34?as=iiif",
+      "type": "Manifest",
+      "homepage": [
+        {
+          "id": "https://dc.library.northwestern.edu/items/c4b05936-2202-4d52-b7ab-9d02480c6c34",
+          "type": "Text",
+          "format": "text/html",
+          "label": {
+            "none": ["Project Survival Teach-out. Parts 1, 6, and 7"]
+          }
+        }
+      ],
+      "label": {
+        "none": ["Project Survival Teach-out. Parts 1, 6, and 7"]
+      },
+      "summary": {
+        "none": ["Video"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://api.dc.library.northwestern.edu/api/v2/works/c4b05936-2202-4d52-b7ab-9d02480c6c34/thumbnail",
+          "format": "image/jpeg",
+          "type": "Image",
+          "width": 400,
+          "height": 400
+        }
+      ]
+    },
+    {
+      "id": "https://api.dc.library.northwestern.edu/api/v2/works/dcde7d05-c563-4ee2-bf0d-39fba0212df0?as=iiif",
+      "type": "Manifest",
+      "homepage": [
+        {
+          "id": "https://dc.library.northwestern.edu/items/dcde7d05-c563-4ee2-bf0d-39fba0212df0",
+          "type": "Text",
+          "format": "text/html",
+          "label": {
+            "none": [
+              "Makeup of the National Assembly : distribution of national and provincial seats."
+            ]
+          }
+        }
+      ],
+      "label": {
+        "none": [
+          "Makeup of the National Assembly : distribution of national and provincial seats."
+        ]
+      },
+      "summary": {
+        "none": ["Image"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://api.dc.library.northwestern.edu/api/v2/works/dcde7d05-c563-4ee2-bf0d-39fba0212df0/thumbnail",
+          "format": "image/jpeg",
+          "type": "Image",
+          "width": 400,
+          "height": 400
+        }
+      ]
+    },
+    {
+      "id": "https://api.dc.library.northwestern.edu/api/v2/works/522f6909-faa7-4425-a5a4-d93ee6faada7?as=iiif",
+      "type": "Manifest",
+      "homepage": [
+        {
+          "id": "https://dc.library.northwestern.edu/items/522f6909-faa7-4425-a5a4-d93ee6faada7",
+          "type": "Text",
+          "format": "text/html",
+          "label": {
+            "none": ["Assembly Building. Aerial view"]
+          }
+        }
+      ],
+      "label": {
+        "none": ["Assembly Building. Aerial view"]
+      },
+      "summary": {
+        "none": ["Image"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://api.dc.library.northwestern.edu/api/v2/works/522f6909-faa7-4425-a5a4-d93ee6faada7/thumbnail",
+          "format": "image/jpeg",
+          "type": "Image",
+          "width": 400,
+          "height": 400,
+          "service": [
+            {
+              "@id": "https://iiif.dc.library.northwestern.edu/iiif/2/a6a99751-b15e-44c9-91f3-3838e0a206c1",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://api.dc.library.northwestern.edu/api/v2/works/be3fcc3e-c627-40a8-9a17-b982dd5ff31a?as=iiif",
+      "type": "Manifest",
+      "homepage": [
+        {
+          "id": "https://dc.library.northwestern.edu/items/be3fcc3e-c627-40a8-9a17-b982dd5ff31a",
+          "type": "Text",
+          "format": "text/html",
+          "label": {
+            "none": ["Sam Hinton concert program"]
+          }
+        }
+      ],
+      "label": {
+        "none": ["Sam Hinton concert program"]
+      },
+      "summary": {
+        "none": ["Image"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://api.dc.library.northwestern.edu/api/v2/works/be3fcc3e-c627-40a8-9a17-b982dd5ff31a/thumbnail",
+          "format": "image/jpeg",
+          "type": "Image",
+          "width": 400,
+          "height": 400
+        }
+      ]
+    },
+    {
+      "id": "https://api.dc.library.northwestern.edu/api/v2/works/ca750b67-8e03-44a9-a790-63e386cde962?as=iiif",
+      "type": "Manifest",
+      "homepage": [
+        {
+          "id": "https://dc.library.northwestern.edu/items/ca750b67-8e03-44a9-a790-63e386cde962",
+          "type": "Text",
+          "format": "text/html",
+          "label": {
+            "none": ["United Nations declaration against apartheid"]
+          }
+        }
+      ],
+      "label": {
+        "none": ["United Nations declaration against apartheid"]
+      },
+      "summary": {
+        "none": ["Image"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://api.dc.library.northwestern.edu/api/v2/works/ca750b67-8e03-44a9-a790-63e386cde962/thumbnail",
+          "format": "image/jpeg",
+          "type": "Image",
+          "width": 400,
+          "height": 400
+        }
+      ]
+    },
+    {
+      "id": "https://api.dc.library.northwestern.edu/api/v2/works/dd398918-c876-4f03-8b2b-cdc3f734bff6?as=iiif",
+      "type": "Manifest",
+      "homepage": [
+        {
+          "id": "https://dc.library.northwestern.edu/items/dd398918-c876-4f03-8b2b-cdc3f734bff6",
+          "type": "Text",
+          "format": "text/html",
+          "label": {
+            "none": ["Palace of the Assembly. Interior view of assembly hall"]
+          }
+        }
+      ],
+      "label": {
+        "none": ["Palace of the Assembly. Interior view of assembly hall"]
+      },
+      "summary": {
+        "none": ["Image"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://api.dc.library.northwestern.edu/api/v2/works/dd398918-c876-4f03-8b2b-cdc3f734bff6/thumbnail",
+          "format": "image/jpeg",
+          "type": "Image",
+          "width": 400,
+          "height": 400
+        }
+      ]
+    },
+    {
+      "id": "https://api.dc.library.northwestern.edu/api/v2/works/ce46512a-5399-4050-8aad-6c4357eb89ce?as=iiif",
+      "type": "Manifest",
+      "homepage": [
+        {
+          "id": "https://dc.library.northwestern.edu/items/ce46512a-5399-4050-8aad-6c4357eb89ce",
+          "type": "Text",
+          "format": "text/html",
+          "label": {
+            "none": [
+              "The new provinces and their seats in the National Assembly."
+            ]
+          }
+        }
+      ],
+      "label": {
+        "none": ["The new provinces and their seats in the National Assembly."]
+      },
+      "summary": {
+        "none": ["Image"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://api.dc.library.northwestern.edu/api/v2/works/ce46512a-5399-4050-8aad-6c4357eb89ce/thumbnail",
+          "format": "image/jpeg",
+          "type": "Image",
+          "width": 400,
+          "height": 400
+        }
+      ]
+    },
+    {
+      "id": "https://api.dc.library.northwestern.edu/api/v2/works/a8777918-3b38-41b0-90f2-605ebcb60bb4?as=iiif",
+      "type": "Manifest",
+      "homepage": [
+        {
+          "id": "https://dc.library.northwestern.edu/items/a8777918-3b38-41b0-90f2-605ebcb60bb4",
+          "type": "Text",
+          "format": "text/html",
+          "label": {
+            "none": [
+              "Main Dukhang (assembly hall), with photograph on throne for the Dalai Lama and hanging banners and thangkas in front of glassed in altar with sculptures. Interior"
+            ]
+          }
+        }
+      ],
+      "label": {
+        "none": [
+          "Main Dukhang (assembly hall), with photograph on throne for the Dalai Lama and hanging banners and thangkas in front of glassed in altar with sculptures. Interior"
+        ]
+      },
+      "summary": {
+        "none": ["Image"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://api.dc.library.northwestern.edu/api/v2/works/a8777918-3b38-41b0-90f2-605ebcb60bb4/thumbnail",
+          "format": "image/jpeg",
+          "type": "Image",
+          "width": 400,
+          "height": 400
+        }
+      ]
+    },
+    {
+      "id": "https://api.dc.library.northwestern.edu/api/v2/works/f133c859-0d11-4ac7-89f8-7c496166a44e?as=iiif",
+      "type": "Manifest",
+      "homepage": [
+        {
+          "id": "https://dc.library.northwestern.edu/items/f133c859-0d11-4ac7-89f8-7c496166a44e",
+          "type": "Text",
+          "format": "text/html",
+          "label": {
+            "none": [
+              "The new Parliament : Constitutional Assembly (sitting together)."
+            ]
+          }
+        }
+      ],
+      "label": {
+        "none": [
+          "The new Parliament : Constitutional Assembly (sitting together)."
+        ]
+      },
+      "summary": {
+        "none": ["Image"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://api.dc.library.northwestern.edu/api/v2/works/f133c859-0d11-4ac7-89f8-7c496166a44e/thumbnail",
+          "format": "image/jpeg",
+          "type": "Image",
+          "width": 400,
+          "height": 400
+        }
+      ]
+    },
+    {
+      "id": "https://api.dc.library.northwestern.edu/api/v2/search?as=iiif&query=assembly&page=2",
+      "type": "Collection",
+      "label": {
+        "none": ["Next page"]
+      }
+    }
+  ]
+}

--- a/src/components/Figure/Figure.tsx
+++ b/src/components/Figure/Figure.tsx
@@ -34,11 +34,8 @@ const Figure: React.FC<FigureProps> = ({
       <AspectRatio.Root ratio={1 / 1}>
         <Width ref={widthRef} />
         <Placeholder>
-          {thumbnail && status === 200 ? (
-            <Thumbnail altAsLabel={label} thumbnail={thumbnail} />
-          ) : (
-            <StatusIcon status={status} />
-          )}
+          {status !== 200 && <StatusIcon status={status} />}
+          <Thumbnail altAsLabel={label} thumbnail={thumbnail} />
         </Placeholder>
       </AspectRatio.Root>
       <figcaption>

--- a/src/components/Figure/StatusIcon.tsx
+++ b/src/components/Figure/StatusIcon.tsx
@@ -54,8 +54,9 @@ const StyledStatusIcon = styled("div", {
   alignItems: "center",
   justifyContent: "center",
   position: "absolute",
-  left: "50%",
-  top: "50%",
+  zIndex: "1",
+  bottom: "1rem",
+  right: "1rem",
   margin: "-1rem 0 0 -1rem",
   boxShadow: "5px 5px 13px #0003",
 

--- a/src/context/collection-context.tsx
+++ b/src/context/collection-context.tsx
@@ -1,11 +1,9 @@
 import React from "react";
-import { Vault } from "@iiif/vault";
 import { ConfigOptions } from "../types/types";
 
 interface CollectionContextStore {
   isLoaded: boolean;
   options: ConfigOptions;
-  vault: Vault;
 }
 
 interface CollectionAction {
@@ -19,7 +17,6 @@ export const defaultState: CollectionContextStore = {
     enablePreview: false,
     credentials: "omit",
   },
-  vault: new Vault(),
 };
 
 const CollectionStateContext =

--- a/src/dev/collections.ts
+++ b/src/dev/collections.ts
@@ -1,5 +1,9 @@
 export const collections = [
   {
+    url: "https://api.dc.library.northwestern.edu/api/v2/search?query=assembly&as=iiif",
+    label: "mixed access",
+  },
+  {
     url: "https://api.dc.library.northwestern.edu/api/v2/collections/c373ecd2-2c45-45f2-9f9e-52dc244870bd?as=iiif",
     label: "Masks of Antonio Fava",
   },

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -16,6 +16,7 @@ import Items from "components/Items/Items";
 import hash from "lib/hash";
 import { ErrorBoundary } from "react-error-boundary";
 import ErrorFallback from "components/ErrorFallback/ErrorFallback";
+import { upgrade } from "@iiif/parser/upgrader";
 
 interface BloomProps {
   collectionId: string;
@@ -35,24 +36,20 @@ const App: React.FC<BloomProps> = (props) => (
 
 const Bloom: React.FC<BloomProps> = ({ collectionId }) => {
   const store = useCollectionState();
-  const { vault, options } = store;
+  const { options } = store;
   const [collection, setCollection] = useState<CollectionNormalized>();
-  const [error, setError] = useState("");
 
   useEffect(() => {
     if (!collectionId) return;
-    vault
-      .loadCollection(collectionId)
+    fetch(collectionId)
+      .then((response) => response.json())
+      .then(upgrade)
       .then((data: any) => setCollection(data))
       .catch((error: any) => {
         console.error(
           `The IIIF Collection ${collectionId} failed to load: ${error}`
         );
-        setError(
-          error instanceof Error ? error.message : `Collection failed to load`
-        );
-      })
-      .finally(() => {});
+      });
   }, [collectionId]);
 
   if (collection?.items.length === 0) {

--- a/src/lib/iiif.ts
+++ b/src/lib/iiif.ts
@@ -1,8 +1,13 @@
-import { CanvasNormalized } from "@iiif/presentation-3";
+import { Canvas, IIIFExternalWebResource } from "@iiif/presentation-3";
 
-export const getCanvasResource = (canvas: CanvasNormalized, vault) => {
-  if (canvas.thumbnail.length !== 0) return canvas.thumbnail;
-  const annotationPage = vault.get(canvas.items[0]);
-  const annotation = vault.get(annotationPage.items[0]);
-  return annotation.body;
+export const getCanvasResource = (canvas: Canvas) => {
+  if (canvas?.items) {
+    const annotationPage = canvas?.items[0];
+    if (annotationPage?.items) {
+      const resource = annotationPage?.items[0].body as IIIFExternalWebResource;
+      if (resource?.hasOwnProperty("id")) {
+        return resource.id as string;
+      }
+    }
+  }
 };


### PR DESCRIPTION
## What does this do?

This adds "Lock" icon for content resources that return a 403, indicating to the user that there is some access restrictions on the homepage for that particular item.

The logic behind this:

- Fetch IIIF Collection
- If Items with the Collection are Manifests, fetch Content Resource headers and check if 403.

![image](https://user-images.githubusercontent.com/7376450/230149994-edc8034e-0847-48f6-9024-8187c603fb8e.png)
 
Additionally, this work swaps out Vault for the lighter (redux-free) `upgrade` helper in @iiif/parser.