### PR TITLE
Add `onItemInteraction` callback prop.

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,51 +90,63 @@ The default behavior for a click (or press) event on each of the individual item
 
 You can optionally set an event handler for the `onItemInteraction` value as a callback for a custom action. The full `item` object will be passed back to the consuming application.
 
-```jsx
-const handleItemInteraction = (item) => {
-  console.log(item);
-}
+#### Example usage of `onItemInteraction` callback:
 
-<BloomIIIF
-  collectionId={...}
-  onItemInteraction={handleItemInteraction}
-/>
+```jsx
+import BloomIIIF from "@samvera/bloom-iiif";
+
+// import swiper.js styling
+import "swiper/css";
+import "swiper/css/lazy";
+import "swiper/css/navigation";
+import "swiper/css/pagination";
+
+const MyApp = () => {
+  const collectionId =
+    "https://api.dc.library.northwestern.edu/api/v2/collections/c373ecd2-2c45-45f2-9f9e-52dc244870bd?as=iiif";
+  const handleItemInteraction = (item: Manifest | Collection) => {
+    console.log(`item`, item);
+    // do something with `item`
+  };
+
+  return (
+    <BloomIIIF
+      collectionId={collectionId}
+      onItemInteraction={handleItemInteraction}
+    />
+  );
+};
 ```
+
+#### Example `item` return value:
 
 ```json
 {
-  "id": "http://127.0.0.1:8080/fixtures/iiif/manifest/nez-perce/01-half-moon.json",
+  "id": "https://api.dc.library.northwestern.edu/api/v2/works/2de0355c-8e48-4478-93af-8cbd1437bd16?as=iiif",
   "type": "Manifest",
+  "homepage": [
+    {
+      "id": "https://dc.library.northwestern.edu/items/2de0355c-8e48-4478-93af-8cbd1437bd16",
+      "type": "Text",
+      "format": "text/html",
+      "label": {
+        "none": ["Pulcinella \"tiepolano\""]
+      }
+    }
+  ],
   "label": {
-    "none": ["Half Moon - Nez Percé"]
+    "none": ["Pulcinella \"tiepolano\""]
   },
   "summary": {
     "none": ["Image"]
   },
   "thumbnail": [
     {
-      "id": "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/1ce40089-9317-4dc7-823a-3af757d55c5d/full/200,/0/default.jpg",
-      "type": "Image",
+      "id": "https://api.dc.library.northwestern.edu/api/v2/works/2de0355c-8e48-4478-93af-8cbd1437bd16/thumbnail",
       "format": "image/jpeg",
-      "service": [
-        {
-          "id": "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/1ce40089-9317-4dc7-823a-3af757d55c5d",
-          "profile": "http://iiif.io/api/image/2/level2.json",
-          "type": "ImageService2"
-        }
-      ],
-      "width": 200,
-      "height": 200
-    }
-  ],
-  "homepage": [
-    {
-      "id": "https://dc.library.northwestern.edu/items/9bda3bba-18f6-467e-be96-3bbd079dabdb",
-      "type": "Text",
-      "label": {
-        "none": ["Half Moon - Nez Percé"]
-      },
-      "format": "text/html"
+      "type": "Image",
+      "width": 400,
+      "height": 400
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -84,6 +84,62 @@ const myBreakpoints = {
 />
 ```
 
+<h3>Item Interaction Callback (optional)</h3>
+
+The default behavior for a click (or press) event on each of the individual items is to route to the `href` value set by the IIIF Presentation 3.0 API `homepage[0].id` for each `item` entry.
+
+You can optionally set an event handler for the `onItemInteraction` value as a callback for a custom action. The full `item` object will be passed back to the consuming application.
+
+```jsx
+const handleItemInteraction = (item) => {
+  console.log(item);
+}
+
+<BloomIIIF
+  collectionId={...}
+  onItemInteraction={handleItemInteraction}
+/>
+```
+
+```json
+{
+  "id": "http://127.0.0.1:8080/fixtures/iiif/manifest/nez-perce/01-half-moon.json",
+  "type": "Manifest",
+  "label": {
+    "none": ["Half Moon - Nez Percé"]
+  },
+  "summary": {
+    "none": ["Image"]
+  },
+  "thumbnail": [
+    {
+      "id": "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/1ce40089-9317-4dc7-823a-3af757d55c5d/full/200,/0/default.jpg",
+      "type": "Image",
+      "format": "image/jpeg",
+      "service": [
+        {
+          "id": "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/1ce40089-9317-4dc7-823a-3af757d55c5d",
+          "profile": "http://iiif.io/api/image/2/level2.json",
+          "type": "ImageService2"
+        }
+      ],
+      "width": 200,
+      "height": 200
+    }
+  ],
+  "homepage": [
+    {
+      "id": "https://dc.library.northwestern.edu/items/9bda3bba-18f6-467e-be96-3bbd079dabdb",
+      "type": "Text",
+      "label": {
+        "none": ["Half Moon - Nez Percé"]
+      },
+      "format": "text/html"
+    }
+  ]
+}
+```
+
 <h3>Next.js</h3>
 
 Usage with Next.js requires a dynamic import using `next/dynamic`

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -23,7 +23,7 @@ const Header: React.FC<HeaderProps> = ({
   const [hasHomepage, setHasHomepage] = useState<boolean>(false);
 
   useEffect(() => {
-    if (homepage.length > 0) setHasHomepage(true);
+    if (homepage?.length > 0) setHasHomepage(true);
   }, [homepage]);
 
   return (

--- a/src/components/Items/Item.tsx
+++ b/src/components/Items/Item.tsx
@@ -4,12 +4,7 @@ import {
   IIIFExternalWebResource,
   Manifest,
 } from "@iiif/presentation-3";
-import React, {
-  MouseEvent,
-  MouseEventHandler,
-  useEffect,
-  useState,
-} from "react";
+import React, { MouseEvent, useEffect, useState } from "react";
 import Figure from "components/Figure/Figure";
 import Placeholder from "./Placeholder";
 import { getCanvasResource } from "lib/iiif";

--- a/src/components/Items/Item.tsx
+++ b/src/components/Items/Item.tsx
@@ -4,7 +4,12 @@ import {
   IIIFExternalWebResource,
   Manifest,
 } from "@iiif/presentation-3";
-import React, { useEffect, useState } from "react";
+import React, {
+  MouseEvent,
+  MouseEventHandler,
+  useEffect,
+  useState,
+} from "react";
 import Figure from "components/Figure/Figure";
 import Placeholder from "./Placeholder";
 import { getCanvasResource } from "lib/iiif";
@@ -12,11 +17,12 @@ import { useCollectionState } from "context/collection-context";
 import { upgrade } from "@iiif/parser/upgrader";
 
 interface ItemProps {
+  handleItemInteraction?: (item: Collection | Manifest) => void;
   index: number;
   item: Collection | Manifest;
 }
 
-const Item: React.FC<ItemProps> = ({ index, item }) => {
+const Item: React.FC<ItemProps> = ({ handleItemInteraction, index, item }) => {
   const store = useCollectionState();
   const { options } = store;
   const { credentials } = options;
@@ -62,10 +68,23 @@ const Item: React.FC<ItemProps> = ({ index, item }) => {
   const onFocus = () => setIsFocused(true);
   const onBlur = () => setIsFocused(false);
 
+  /**
+   * if a handleItemInteraction() callback is present
+   * pass `item` object up to consuming application.
+   * if not, allow browser to route user to href value.
+   */
+  const handleAnchorClick = (e: MouseEvent<HTMLAnchorElement>) => {
+    if (!handleItemInteraction) return;
+
+    e.preventDefault();
+    handleItemInteraction(item);
+  };
+
   return (
     <ItemStyled>
       <Anchor
         href={href}
+        onClick={handleAnchorClick}
         tabIndex={0}
         onFocus={onFocus}
         onBlur={onBlur}

--- a/src/components/Items/Items.tsx
+++ b/src/components/Items/Items.tsx
@@ -8,6 +8,7 @@ import { Swiper, SwiperSlide } from "swiper/react";
 
 interface ItemsProps {
   breakpoints?: SwiperBreakpoints;
+  handleItemInteraction?: (item: Collection | Manifest) => void;
   instance: number;
   items: CollectionItems[];
 }
@@ -42,6 +43,7 @@ const defaultBreakpoints = {
 
 const Items: React.FC<ItemsProps> = ({
   breakpoints = defaultBreakpoints,
+  handleItemInteraction,
   instance,
   items,
 }) => {
@@ -70,7 +72,11 @@ const Items: React.FC<ItemsProps> = ({
             data-index={index}
             data-type={item?.type.toLowerCase()}
           >
-            <Item index={index} item={item as Collection | Manifest} />
+            <Item
+              handleItemInteraction={handleItemInteraction}
+              index={index}
+              item={item as Collection | Manifest}
+            />
           </SwiperSlide>
         ))}
       </Swiper>

--- a/src/dev.tsx
+++ b/src/dev.tsx
@@ -8,14 +8,23 @@ import App from "./index";
 import DynamicUrl from "./dev/DynamicUrl";
 import { collections } from "./dev/collections";
 import { createRoot } from "react-dom/client";
+import { Collection, Manifest } from "@iiif/presentation-3";
 
 const Wrapper = () => {
   const defaultUrl: string = collections[0].url;
-
   const [url, setUrl] = React.useState(defaultUrl);
+
+  const handleItemInteraction = (item: Manifest | Collection) => {
+    console.log(`item`, item);
+  };
+
   return (
     <>
-      <App collectionId={url} key={url} />
+      <App
+        collectionId={url}
+        key={url}
+        onItemInteraction={handleItemInteraction}
+      />
       <DynamicUrl url={url} setUrl={setUrl} />
     </>
   );

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,9 +1,11 @@
 import React, { useEffect, useState } from "react";
 import {
+  Collection,
   CollectionItems,
   CollectionNormalized,
   ContentResource,
   InternationalString,
+  Manifest,
 } from "@iiif/presentation-3";
 import {
   CollectionProvider,
@@ -20,6 +22,7 @@ import { upgrade } from "@iiif/parser/upgrader";
 
 interface BloomProps {
   collectionId: string;
+  onItemInteraction?: (item: Manifest | Collection) => void;
   options?: ConfigOptions;
 }
 
@@ -34,7 +37,7 @@ const App: React.FC<BloomProps> = (props) => (
   </CollectionProvider>
 );
 
-const Bloom: React.FC<BloomProps> = ({ collectionId }) => {
+const Bloom: React.FC<BloomProps> = ({ collectionId, onItemInteraction }) => {
   const store = useCollectionState();
   const { options } = store;
   const [collection, setCollection] = useState<CollectionNormalized>();
@@ -76,6 +79,7 @@ const Bloom: React.FC<BloomProps> = ({ collectionId }) => {
         />
         <Items
           items={collection.items as CollectionItems[]}
+          handleItemInteraction={onItemInteraction}
           instance={instance}
           breakpoints={options.breakpoints}
         />


### PR DESCRIPTION
## What does this do?

@martimpassos noted that there is no way for Bloom to handler javascript interactions via a callaback. This adds that functionality while retaining `href` routing as the default method for onClick interactions with items.

This adds the ability for a consuming application to set a callback function for handling item interactions. This is set in the top level `onItemInteraction` prop. If this prop not set, the default behavior will be for the browser to lean on the `href` value of an anchor and route the user to the `homepage[0].id` value.

```jsx
const MyApp = () => {
  const handleItemInteraction = (item: Manifest | Collection) => {
    console.log(`item`, item);
    // do something with `item`
  };

  return (
    <App
      collectionId={url}
      onItemInteraction={handleItemInteraction}
    />
  );
};
```

I also added some minor defensiveness to the homepage.length check. This should now work even if a homepage does not exist.